### PR TITLE
Réécriture de l'imprimé sur les résultats d'analyses en utilisant le plugin fpdf

### DIFF
--- a/module/Admin/config/acl.config.php
+++ b/module/Admin/config/acl.config.php
@@ -316,7 +316,9 @@ return array(
             		'liste-patients-consultes-ajax' => 'medecin',
             		'impression-ordonnance' => 'medecin',
             		'impression-examens-demandes' => 'medecin',
-            			
+            		'impression-un-examen-demande' => 'medecin',
+            		'impression-examens-radio-demandes'  => 'medecin',
+            		'impression-examens-bio-demandes'  => 'medecin',
             			
             		'historiques-des-consultations-du-patient-ajax' => 'medecin',
             		'visualisation-historique-consultation' => 'medecin', 	

--- a/module/Consultation/src/Consultation/Form/ConsultationForm.php
+++ b/module/Consultation/src/Consultation/Form/ConsultationForm.php
@@ -1150,5 +1150,96 @@ class ConsultationForm extends Form {
 				)
 		) );
 		
+		
+		
+		/**Autres (Transfert / Hospitalisation / Rendez-Vous) ---  **/
+		/**Autres (Transfert / Hospitalisation / Rendez-Vous) ---  **/
+		
+		/**
+		 * Rendez-Vous --- Rendez-Vous 
+		 * Rendez-Vous --- Rendez-Vous
+		 */
+		$this->add ( array (
+				'name' => 'dateHeureRendezVous',
+				'type' => 'Zend\Form\Element\Text',
+				'options' => array (
+						'label' => 'Date & Heure'
+				),
+				'attributes' => array (
+						'id' => 'dateHeureRendezVous',
+						'style' => 'font-weight: bold; font-size: 17px;'
+				)
+		) );
+		
+		$this->add ( array (
+				'name' => 'motifRendezVous',
+				'type' => 'Zend\Form\Element\Textarea',
+				'attributes' => array (
+						'id' => 'motifRendezVous',
+						'style' => 'height: 135px; min-height: 135px; max-height: 135px;'
+				)
+		) );
+		
+		
+		/**
+		 * Hospitalisation --- Hospitalisation
+		 * Hospitalisation --- Hospitalisation
+		 */
+		$this->add ( array (
+				'name' => 'motifHospitalisation',
+				'type' => 'Zend\Form\Element\Textarea',
+				'options' => array (
+						'label' => 'Motif'
+				),
+				'attributes' => array (
+						'id' => 'motifHospitalisation',
+						'style' => 'height: 135px; min-height: 135px; max-height: 135px;'
+				)
+		) );
+		
+		
+		/**
+		 * Transfert --- Transfert --- Transfert
+		 * Transfert --- Transfert --- Transfert
+		 */
+		
+		$this->add ( array (
+				'name' => 'motifTransfert',
+				'type' => 'Zend\Form\Element\Textarea',
+				'options' => array (
+						'label' => 'Motif'
+				),
+				'attributes' => array (
+						'id' => 'motifTransfert',
+						'style' => 'height: 135px; min-height: 135px; max-height: 135px;'
+				)
+		) );
+		
+		$this->add ( array (
+				'name' => 'hopitalAccueil',
+				'type' => 'Zend\Form\Element\Text',
+				'options' => array (
+						'label' => 'Hopital'
+				),
+				'attributes' => array (
+						'id' => 'hopitalAccueil',
+						'style' => 'font-weight: bold; font-size: 17px;'
+				)
+		) );
+		
+		
+		$this->add ( array (
+				'name' => 'serviceAccueil',
+				'type' => 'Zend\Form\Element\Text',
+				'options' => array (
+						'label' => 'Service'
+				),
+				'attributes' => array (
+						'id' => 'serviceAccueil',
+						'style' => 'font-weight: bold; font-size: 17px;'
+				)
+		) );
+		
+		
 	}
 }

--- a/module/Consultation/src/Consultation/View/Helper/ImprimerExamensBioDemandes.php
+++ b/module/Consultation/src/Consultation/View/Helper/ImprimerExamensBioDemandes.php
@@ -1,0 +1,422 @@
+<?php
+namespace Consultation\View\Helper;
+
+use Consultation\View\Helper\fpdf181\fpdf;
+use Secretariat\View\Helper\DateHelper;
+
+class ImprimerExamensBioDemandes extends fpdf
+{
+
+	function Footer()
+	{
+		// Positionnement à 1,5 cm du bas
+		$this->SetY(-15);
+		
+		$this->SetFillColor(0,128,0);
+		$this->Cell(0,0.3,"",0,1,'C',true);
+		$this->SetTextColor(0,0,0);
+		$this->SetFont('Times','',9.5);
+		$this->Cell(81,5,'Téléphone: 33 000 00 00 ',0,0,'L',false);
+		$this->SetTextColor(128);
+		$this->SetFont('Times','I',9);
+		$this->Cell(20,8,'' /*'Page '.$this->PageNo()*/,0,0,'C',false);
+		$this->SetTextColor(0,0,0);
+		$this->SetFont('Times','',9.5);
+		$this->Cell(81,5,'SIMENS+: www.simens.sn',0,0,'R',false);
+	}
+	
+	protected $B = 0;
+	protected $I = 0;
+	protected $U = 0;
+	protected $HREF = '';
+	
+	function WriteHTML($html)
+	{
+		// Parseur HTML
+		$html = str_replace("\n",' ',$html);
+		$a = preg_split('/<(.*)>/U',$html,-1,PREG_SPLIT_DELIM_CAPTURE);
+		foreach($a as $i=>$e)
+		{
+			if($i%2==0)
+			{
+				// Texte
+				if($this->HREF)
+					$this->PutLink($this->HREF,$e);
+				else
+					$this->Write(5,$e);
+			}
+			else
+			{
+				// Balise
+				if($e[0]=='/')
+					$this->CloseTag(strtoupper(substr($e,1)));
+				else
+				{
+					// Extraction des attributs
+					$a2 = explode(' ',$e);
+					$tag = strtoupper(array_shift($a2));
+					$attr = array();
+					foreach($a2 as $v)
+					{
+						if(preg_match('/([^=]*)=["\']?([^"\']*)/',$v,$a3))
+							$attr[strtoupper($a3[1])] = $a3[2];
+					}
+					$this->OpenTag($tag,$attr);
+				}
+			}
+		}
+	}
+	
+	function OpenTag($tag, $attr)
+	{
+		// Balise ouvrante
+		if($tag=='B' || $tag=='I' || $tag=='U')
+			$this->SetStyle($tag,true);
+		if($tag=='A')
+			$this->HREF = $attr['HREF'];
+		if($tag=='BR')
+			$this->Ln(5);
+	}
+	
+	function CloseTag($tag)
+	{
+		// Balise fermante
+		if($tag=='B' || $tag=='I' || $tag=='U')
+			$this->SetStyle($tag,false);
+		if($tag=='A')
+			$this->HREF = '';
+	}
+	
+	function SetStyle($tag, $enable)
+	{
+		// Modifie le style et sélectionne la police correspondante
+		$this->$tag += ($enable ? 1 : -1);
+		$style = '';
+		foreach(array('B', 'I', 'U') as $s)
+		{
+			if($this->$s>0)
+				$style .= $s;
+		}
+		$this->SetFont('',$style);
+	}
+	
+	function PutLink($URL, $txt)
+	{
+		// Place un hyperlien
+		$this->SetTextColor(0,0,255);
+		$this->SetStyle('U',true);
+		$this->Write(5,$txt,$URL);
+		$this->SetStyle('U',false);
+		$this->SetTextColor(0);
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	protected $tabInformations ;
+	protected $nomService;
+	protected $infosComp;
+	protected $PeriodePrelevement;
+
+	public function setTabInformations($tabInformations)
+	{
+		$this->tabInformations = $tabInformations;
+	}
+	
+	public function getTabInformations()
+	{
+		return $this->tabInformations;
+	}
+	
+	public function getNomService()
+	{
+		return $this->nomService;
+	}
+	
+	public function setNomService($nomService)
+	{
+		$this->nomService = $nomService;
+	}
+	
+	public function getPeriodePrelevement()
+	{
+		return $this->PeriodePrelevement;
+	}
+	
+	public function setPeriodePrelevement($PeriodePrelevement)
+	{
+		$this->PeriodePrelevement = $PeriodePrelevement;
+	}
+
+	public function getInfosComp()
+	{
+		return $this->infosComp;
+	}
+	
+	public function setInfosComp($infosComp)
+	{
+		$this->infosComp = $infosComp;
+	}
+	
+	
+	protected $infosPatients;
+	protected $motifExamenDem;
+	protected $typeExamen;
+	protected $idExamen;
+	protected $libelleExamen;
+	
+	
+	public function getInfosPatients()
+	{
+		return $this->infosPatients;
+	}
+	
+	public function setInfosPatients($infosPatients)
+	{
+		$this->infosPatients = $infosPatients;
+	}
+	
+	public function getMotifExamenDem()
+	{
+		return $this->motifExamenDem;
+	}
+	
+	public function setMotifExamenDem($motifExamenDem)
+	{
+		$this->motifExamenDem = $motifExamenDem;
+	}
+	
+	public function getTypeExamen()
+	{
+		return $this->typeExamen;
+	}
+	
+	public function setTypeExamen($typeExamen)
+	{
+		$this->typeExamen = $typeExamen;
+	}
+	
+	public function getIdExamen()
+	{
+		return $this->idExamen;
+	}
+	
+    public function setIdExamen($idExamen)
+	{
+		$this->idExamen = $idExamen;
+	}
+	
+	public function getLibelleExamen()
+	{
+		return $this->libelleExamen;
+	}
+	
+	public function setLibelleExamen($libelleExamen)
+	{
+		$this->libelleExamen = $libelleExamen;
+	}
+	
+	
+	protected function nbJours($debut, $fin) {
+		//60 secondes X 60 minutes X 24 heures dans une journee
+		$nbSecondes = 60*60*24;
+	
+		$debut_ts = strtotime($debut);
+		$fin_ts = strtotime($fin);
+		$diff = $fin_ts - $debut_ts;
+		return ($diff / $nbSecondes);
+	}
+	
+	function EnTetePage()
+	{
+		$this->SetFont('Times','',10.3);
+		$this->SetTextColor(0,0,0);
+		$this->Cell(0,4,"République du Sénégal");
+		$this->SetFont('Times','',8.5);
+		$this->Cell(0,4,"",0,0,'R');
+		$this->SetFont('Times','',10.3);
+		$this->Ln(5.4);
+		$this->Cell(100,4,"Ministère de la santé et de l'action sociale");
+		
+		$this->AddFont('timesbi','','timesbi.php');
+		$this->Ln(5.4);
+		$this->Cell(100,4,"C.E.R.P.A.D de Saint-louis");
+		$this->Ln(5.4);
+		$this->SetFont('timesbi','',10.3);
+		$this->Cell(14,4,"Service : ",0,0,'L');
+		$this->SetFont('Times','',10.3);
+		$this->Cell(86,4,$this->getNomService(),0,0,'L');
+		
+		$this->Ln(6);
+		$this->SetFont('Times','',13);
+		$this->SetTextColor(0,128,0);
+		$this->Cell(0,-3,"DEMANDE D'EXAMENS",0,0,'C');
+		$this->Ln(1);
+		$this->SetFont('Times','',12.3);
+		$this->SetFillColor(0,128,0);
+		$this->Cell(0,0.3,"",0,1,'C',true);
+	
+		// EMPLACEMENT DU LOGO
+		// EMPLACEMENT DU LOGO
+		$baseUrl = $_SERVER['SCRIPT_FILENAME'];
+		$tabURI  = explode('public', $baseUrl);
+		$this->Image($tabURI[0].'public/images_icons/CERPAD_UGB_LOGO_M.png', 162, 12, 35, 22);
+		
+		// EMPLACEMENT DES INFORMATIONS SUR LE PATIENT
+		// EMPLACEMENT DES INFORMATIONS SUR LE PATIENT
+		$infoPatients = $this->getInfosPatients();
+		$this->SetFont('Times','B',8.5);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(1);
+		$this->Cell(90,4,"PRENOM ET NOM :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(92,4,iconv ('UTF-8' , 'windows-1252', $infoPatients->prenom).' '.iconv ('UTF-8' , 'windows-1252', $infoPatients->nom),0,0,'L'); }
+		
+		$this->SetFont('Times','B',8.5);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(5);
+		$this->Cell(90,4,"SEXE :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(92,4,iconv ('UTF-8' , 'windows-1252', $infoPatients->sexe),0,0,'L'); }
+		
+		//GESTION DES AGES
+		//GESTION DES AGES
+		$age = $infoPatients->age;
+		$aujourdhui = (new \DateTime() ) ->format('Y-m-d');
+		if(!$age){
+		
+			$age_jours = $this->nbJours($infoPatients->date_naissance, $aujourdhui);
+			if($age_jours < 31) {
+				$age = $age_jours." jours";
+			}
+			else
+			if($age_jours >= 31) {
+				$nb_mois = (int)($age_jours/30);
+				$nb_jours = $age_jours - ($nb_mois*30);
+				$age = $nb_mois."m ".$nb_jours."j";
+			}
+		
+		}else{
+		
+			$age = $age." ans";
+		
+		}
+		
+		$convertDate = new DateHelper();
+		
+		$this->SetFont('Times','B',8.5);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(5);
+		$this->Cell(90,4,"DATE DE NAISSANCE (age) :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(92,4, $convertDate->convertDate($infoPatients->date_naissance).' ('.$age.')',0,0,'L'); }
+		
+		$this->SetFont('Times','B',8.5);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(5);
+		$this->Cell(90,4,"TELEPHONE :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(72,4,$infoPatients->telephone,0,0,'L'); }
+		
+		$this->Ln(5);
+		$this->SetFillColor(0,128,0);
+		$this->Cell(0,0.3,"",0,1,'C',true);
+		
+		$this->Ln(2);
+		$this->AddFont('timesi','','timesi.php');
+		$this->SetFont('timesi','',8);
+		$this->Cell(183,1,"Imprimé le : ".$convertDate->convertDate($aujourdhui),0,1,'R');
+	}
+	
+	public function moisEnLettre($mois){
+		$lesMois = array('','Janvier','Fevrier','Mars','Avril',
+				'Mais','Juin','Juillet','Aout','Septembre','Octobre','Novembre','Decembre');
+		return $lesMois[$mois];
+	}
+	
+	function CorpsDocumentExamensBio()
+	{
+		$this->AddFont('zap','','zapfdingbats.php');
+		$this->AddFont('timesb','','timesb.php');
+		$this->AddFont('timesi','','timesi.php');
+		$this->AddFont('times','','times.php');
+	
+		$motifExamenDem = explode(',',$this->getMotifExamenDem());
+		$typeExamen =  explode(',',$this->getTypeExamen());
+		$idExamen =  explode(',',$this->getIdExamen());
+		$libelleExamen =  explode(',',$this->getLibelleExamen());
+		$this->Ln(2);
+	
+		//AFFICHAGE DE L'EXAMEN DEMANDE
+		//AFFICHAGE DE L'EXAMEN DEMANDE
+		$this->SetFillColor(249,249,249);
+		$this->SetDrawColor(220,220,220);
+		
+		//PREMIERE EN-TETE
+		$this->SetFont('zap','',11.3);
+		$this->Cell(4,7,' o','BT',0,'C',1);
+		$this->SetFont('times','',12);
+		$this->Cell(84,7,'Examens demandés : ','BT',0,'L',1);
+	
+		//SEPARATEUR
+		$this->Cell(3,7,'','',0,'C');
+		
+		//SECONDE EN-TETE
+		$this->SetFont('zap','',11.3);
+		$this->Cell(4,7,' o','BT',0,'C',1);
+		$this->SetFont('times','',12);
+		$this->Cell(88,7,"Motif des examens : ",'BT',1,'L',1);
+		$y = $this->GetY();
+		
+		$tousMotifExamenDem = "";
+		
+		for($i=1 ; $i < count($libelleExamen) ; $i++){
+	
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,7,'','',0,'C');
+				$this->Cell(3,7,'+','',0,'C');
+				$this->SetFont('timesi','',10);
+				$this->Cell(82,7, iconv ('UTF-8' , 'windows-1252', ' '.$libelleExamen[$i]),'',1,'L',0);
+				
+				
+				//Récupération des motifs des examens saisis
+				$textDecouper = wordwrap($motifExamenDem[$i], 60, "/n", true); // On découpe le texte
+				if($textDecouper != " "){ $tousMotifExamenDem .= $textDecouper."/n"; }
+			
+		}
+		
+		
+		$textDecouperTab = explode("/n" ,$tousMotifExamenDem); // On le place dans un tableau
+		$motifExamenDemDecoupe = $textDecouperTab;
+		
+		
+		
+		$interLigne = 0;
+		for($iexam=0 ; $iexam<count($motifExamenDemDecoupe) ; $iexam++){
+			$y = 75+$interLigne;
+			
+			$this->Text(108, $y, iconv ('UTF-8' , 'windows-1252', $motifExamenDemDecoupe[$iexam]));
+			
+			$interLigne += 5;
+		}
+		
+	}
+	
+	//IMPRESSION DES INFOS STATISTIQUES
+	//IMPRESSION DES INFOS STATISTIQUES
+	function impressionExamensBioDemandes()
+	{
+		
+		$this->AddPage();
+		$this->EnTetePage();
+		$this->CorpsDocumentExamensBio();
+		
+	}
+
+}
+
+?>

--- a/module/Consultation/src/Consultation/View/Helper/ImprimerExamensRadioDemandes.php
+++ b/module/Consultation/src/Consultation/View/Helper/ImprimerExamensRadioDemandes.php
@@ -1,0 +1,407 @@
+<?php
+namespace Consultation\View\Helper;
+
+use Consultation\View\Helper\fpdf181\fpdf;
+use Secretariat\View\Helper\DateHelper;
+
+class ImprimerExamensRadioDemandes extends fpdf
+{
+
+	function Footer()
+	{
+		// Positionnement à 1,5 cm du bas
+		$this->SetY(-15);
+		
+		$this->SetFillColor(0,128,0);
+		$this->Cell(0,0.3,"",0,1,'C',true);
+		$this->SetTextColor(0,0,0);
+		$this->SetFont('Times','',9.5);
+		$this->Cell(81,5,'Téléphone: 33 000 00 00 ',0,0,'L',false);
+		$this->SetTextColor(128);
+		$this->SetFont('Times','I',9);
+		$this->Cell(20,8,'' /*'Page '.$this->PageNo()*/,0,0,'C',false);
+		$this->SetTextColor(0,0,0);
+		$this->SetFont('Times','',9.5);
+		$this->Cell(81,5,'SIMENS+: www.simens.sn',0,0,'R',false);
+	}
+	
+	protected $B = 0;
+	protected $I = 0;
+	protected $U = 0;
+	protected $HREF = '';
+	
+	function WriteHTML($html)
+	{
+		// Parseur HTML
+		$html = str_replace("\n",' ',$html);
+		$a = preg_split('/<(.*)>/U',$html,-1,PREG_SPLIT_DELIM_CAPTURE);
+		foreach($a as $i=>$e)
+		{
+			if($i%2==0)
+			{
+				// Texte
+				if($this->HREF)
+					$this->PutLink($this->HREF,$e);
+				else
+					$this->Write(5,$e);
+			}
+			else
+			{
+				// Balise
+				if($e[0]=='/')
+					$this->CloseTag(strtoupper(substr($e,1)));
+				else
+				{
+					// Extraction des attributs
+					$a2 = explode(' ',$e);
+					$tag = strtoupper(array_shift($a2));
+					$attr = array();
+					foreach($a2 as $v)
+					{
+						if(preg_match('/([^=]*)=["\']?([^"\']*)/',$v,$a3))
+							$attr[strtoupper($a3[1])] = $a3[2];
+					}
+					$this->OpenTag($tag,$attr);
+				}
+			}
+		}
+	}
+	
+	function OpenTag($tag, $attr)
+	{
+		// Balise ouvrante
+		if($tag=='B' || $tag=='I' || $tag=='U')
+			$this->SetStyle($tag,true);
+		if($tag=='A')
+			$this->HREF = $attr['HREF'];
+		if($tag=='BR')
+			$this->Ln(5);
+	}
+	
+	function CloseTag($tag)
+	{
+		// Balise fermante
+		if($tag=='B' || $tag=='I' || $tag=='U')
+			$this->SetStyle($tag,false);
+		if($tag=='A')
+			$this->HREF = '';
+	}
+	
+	function SetStyle($tag, $enable)
+	{
+		// Modifie le style et sélectionne la police correspondante
+		$this->$tag += ($enable ? 1 : -1);
+		$style = '';
+		foreach(array('B', 'I', 'U') as $s)
+		{
+			if($this->$s>0)
+				$style .= $s;
+		}
+		$this->SetFont('',$style);
+	}
+	
+	function PutLink($URL, $txt)
+	{
+		// Place un hyperlien
+		$this->SetTextColor(0,0,255);
+		$this->SetStyle('U',true);
+		$this->Write(5,$txt,$URL);
+		$this->SetStyle('U',false);
+		$this->SetTextColor(0);
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	protected $tabInformations ;
+	protected $nomService;
+	protected $infosComp;
+	protected $PeriodePrelevement;
+
+	public function setTabInformations($tabInformations)
+	{
+		$this->tabInformations = $tabInformations;
+	}
+	
+	public function getTabInformations()
+	{
+		return $this->tabInformations;
+	}
+	
+	public function getNomService()
+	{
+		return $this->nomService;
+	}
+	
+	public function setNomService($nomService)
+	{
+		$this->nomService = $nomService;
+	}
+	
+	public function getPeriodePrelevement()
+	{
+		return $this->PeriodePrelevement;
+	}
+	
+	public function setPeriodePrelevement($PeriodePrelevement)
+	{
+		$this->PeriodePrelevement = $PeriodePrelevement;
+	}
+
+	public function getInfosComp()
+	{
+		return $this->infosComp;
+	}
+	
+	public function setInfosComp($infosComp)
+	{
+		$this->infosComp = $infosComp;
+	}
+	
+	
+	protected $infosPatients;
+	protected $motifExamenDem;
+	protected $typeExamen;
+	protected $idExamen;
+	protected $libelleExamen;
+	
+	
+	public function getInfosPatients()
+	{
+		return $this->infosPatients;
+	}
+	
+	public function setInfosPatients($infosPatients)
+	{
+		$this->infosPatients = $infosPatients;
+	}
+	
+	public function getMotifExamenDem()
+	{
+		return $this->motifExamenDem;
+	}
+	
+	public function setMotifExamenDem($motifExamenDem)
+	{
+		$this->motifExamenDem = $motifExamenDem;
+	}
+	
+	public function getTypeExamen()
+	{
+		return $this->typeExamen;
+	}
+	
+	public function setTypeExamen($typeExamen)
+	{
+		$this->typeExamen = $typeExamen;
+	}
+	
+	public function getIdExamen()
+	{
+		return $this->idExamen;
+	}
+	
+    public function setIdExamen($idExamen)
+	{
+		$this->idExamen = $idExamen;
+	}
+	
+	public function getLibelleExamen()
+	{
+		return $this->libelleExamen;
+	}
+	
+	public function setLibelleExamen($libelleExamen)
+	{
+		$this->libelleExamen = $libelleExamen;
+	}
+	
+	
+	protected function nbJours($debut, $fin) {
+		//60 secondes X 60 minutes X 24 heures dans une journee
+		$nbSecondes = 60*60*24;
+	
+		$debut_ts = strtotime($debut);
+		$fin_ts = strtotime($fin);
+		$diff = $fin_ts - $debut_ts;
+		return ($diff / $nbSecondes);
+	}
+	
+	function EnTetePage()
+	{
+		$this->SetFont('Times','',10.3);
+		$this->SetTextColor(0,0,0);
+		$this->Cell(0,4,"République du Sénégal");
+		$this->SetFont('Times','',8.5);
+		$this->Cell(0,4,"",0,0,'R');
+		$this->SetFont('Times','',10.3);
+		$this->Ln(5.4);
+		$this->Cell(100,4,"Ministère de la santé et de l'action sociale");
+		
+		$this->AddFont('timesbi','','timesbi.php');
+		$this->Ln(5.4);
+		$this->Cell(100,4,"C.E.R.P.A.D de Saint-louis");
+		$this->Ln(5.4);
+		$this->SetFont('timesbi','',10.3);
+		$this->Cell(14,4,"Service : ",0,0,'L');
+		$this->SetFont('Times','',10.3);
+		$this->Cell(86,4,$this->getNomService(),0,0,'L');
+		
+		$this->Ln(6);
+		$this->SetFont('Times','',13);
+		$this->SetTextColor(0,128,0);
+		$this->Cell(0,-3,"DEMANDE D'EXAMEN",0,0,'C');
+		$this->Ln(1);
+		$this->SetFont('Times','',12.3);
+		$this->SetFillColor(0,128,0);
+		$this->Cell(0,0.3,"",0,1,'C',true);
+	
+		// EMPLACEMENT DU LOGO
+		// EMPLACEMENT DU LOGO
+		$baseUrl = $_SERVER['SCRIPT_FILENAME'];
+		$tabURI  = explode('public', $baseUrl);
+		$this->Image($tabURI[0].'public/images_icons/CERPAD_UGB_LOGO_M.png', 162, 12, 35, 22);
+		
+		// EMPLACEMENT DES INFORMATIONS SUR LE PATIENT
+		// EMPLACEMENT DES INFORMATIONS SUR LE PATIENT
+		$infoPatients = $this->getInfosPatients();
+		$this->SetFont('Times','B',8.5);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(1);
+		$this->Cell(90,4,"PRENOM ET NOM :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(92,4,iconv ('UTF-8' , 'windows-1252', $infoPatients->prenom).' '.iconv ('UTF-8' , 'windows-1252', $infoPatients->nom),0,0,'L'); }
+		
+		$this->SetFont('Times','B',8.5);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(5);
+		$this->Cell(90,4,"SEXE :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(92,4,iconv ('UTF-8' , 'windows-1252', $infoPatients->sexe),0,0,'L'); }
+		
+		//GESTION DES AGES
+		//GESTION DES AGES
+		$age = $infoPatients->age;
+		$aujourdhui = (new \DateTime() ) ->format('Y-m-d');
+		if(!$age){
+		
+			$age_jours = $this->nbJours($infoPatients->date_naissance, $aujourdhui);
+			if($age_jours < 31) {
+				$age = $age_jours." jours";
+			}
+			else
+			if($age_jours >= 31) {
+				$nb_mois = (int)($age_jours/30);
+				$nb_jours = $age_jours - ($nb_mois*30);
+				$age = $nb_mois."m ".$nb_jours."j";
+			}
+		
+		}else{
+		
+			$age = $age." ans";
+		
+		}
+		
+		$convertDate = new DateHelper();
+		
+		$this->SetFont('Times','B',8.5);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(5);
+		$this->Cell(90,4,"DATE DE NAISSANCE (age) :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(92,4, $convertDate->convertDate($infoPatients->date_naissance).' ('.$age.')',0,0,'L'); }
+		
+		$this->SetFont('Times','B',8.5);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(5);
+		$this->Cell(90,4,"TELEPHONE :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(72,4,$infoPatients->telephone,0,0,'L'); }
+		
+		$this->Ln(5);
+		$this->SetFillColor(0,128,0);
+		$this->Cell(0,0.3,"",0,1,'C',true);
+		
+		$this->Ln(2);
+		$this->AddFont('timesi','','timesi.php');
+		$this->SetFont('timesi','',8);
+		$this->Cell(183,1,"Imprimé le : ".$convertDate->convertDate($aujourdhui),0,1,'R');
+	}
+	
+	public function moisEnLettre($mois){
+		$lesMois = array('','Janvier','Fevrier','Mars','Avril',
+				'Mais','Juin','Juillet','Aout','Septembre','Octobre','Novembre','Decembre');
+		return $lesMois[$mois];
+	}
+	
+	function CorpsDocumentExamensRadio($libelleExamen, $motifExamenDem)
+	{
+		$this->AddFont('zap','','zapfdingbats.php');
+		$this->AddFont('timesb','','timesb.php');
+		$this->AddFont('timesi','','timesi.php');
+		$this->AddFont('times','','times.php');
+
+		$this->Ln(2);
+		
+		//AFFICHAGE DE L'EXAMEN DEMANDE
+		//AFFICHAGE DE L'EXAMEN DEMANDE
+		$this->SetFillColor(249,249,249);
+		$this->SetDrawColor(220,220,220);
+		$this->SetFont('zap','',11.3);
+		$this->Cell(3,7,'o','BT',0,'C',1);
+		
+		$this->SetFont('times','',12);
+		$this->Cell(180,7,'Examen demandé : ','BT',1,'L',1);
+				
+		$this->SetFont('zap','',11.3);
+		$this->Cell(10,7,'','',0,'C');
+		$this->Cell(3,7,'+','',0,'C');
+		$this->SetFont('timesi','',10);
+		$this->Cell(170,7, iconv ('UTF-8' , 'windows-1252', ' '.$libelleExamen),'',1,'L',0);
+			
+		
+		//AFFICHAGE DU MOTIF DE L'EXAMEN
+		//AFFICHAGE DU MOTIF DE L'EXAMEN
+		$this->Ln(2);
+		$this->SetFillColor(249,249,249);
+		$this->SetDrawColor(220,220,220);
+		$this->SetFont('zap','',11.3);
+		$this->Cell(3,7,'o','BT',0,'C',1);
+		
+		$this->SetFont('times','',12);
+		$this->Cell(180,7,"Motif de l'examen : ",'BT',1,'L',1);
+		
+		$this->SetFont('zap','',11.3);
+		$this->Cell(3,8,'','',0,'C');
+		$this->SetFont('timesi','',11);
+		$this->MultiCell(180,8, iconv ('UTF-8' , 'windows-1252', ' '.$motifExamenDem),'','L',0);
+
+	}
+	
+	//IMPRESSION DES INFOS STATISTIQUES
+	//IMPRESSION DES INFOS STATISTIQUES
+	function impressionExamensRadioDemandes()
+	{
+		$motifExamenDem = explode(',',$this->getMotifExamenDem());
+		$typeExamen =  explode(',',$this->getTypeExamen());
+		$idExamen =  explode(',',$this->getIdExamen());
+		$libelleExamen =  explode(',',$this->getLibelleExamen());
+		
+		for($i=1 ; $i < count($libelleExamen) ; $i++){
+			
+			if($typeExamen[1] == 6){
+				$this->AddPage();
+				$this->EnTetePage();
+				$this->CorpsDocumentExamensRadio($libelleExamen[$i], $motifExamenDem[$i]);
+			}		
+		}
+		
+	}
+
+}
+
+?>

--- a/module/Consultation/src/Consultation/View/Helper/ImprimerUnExamenDemande.php
+++ b/module/Consultation/src/Consultation/View/Helper/ImprimerUnExamenDemande.php
@@ -1,0 +1,399 @@
+<?php
+namespace Consultation\View\Helper;
+
+use Consultation\View\Helper\fpdf181\fpdf;
+use Secretariat\View\Helper\DateHelper;
+
+class ImprimerUnExamenDemande extends fpdf
+{
+
+	function Footer()
+	{
+		// Positionnement à 1,5 cm du bas
+		$this->SetY(-15);
+		
+		$this->SetFillColor(0,128,0);
+		$this->Cell(0,0.3,"",0,1,'C',true);
+		$this->SetTextColor(0,0,0);
+		$this->SetFont('Times','',9.5);
+		$this->Cell(81,5,'Téléphone: 33 000 00 00 ',0,0,'L',false);
+		$this->SetTextColor(128);
+		$this->SetFont('Times','I',9);
+		$this->Cell(20,8,'' /*'Page '.$this->PageNo()*/,0,0,'C',false);
+		$this->SetTextColor(0,0,0);
+		$this->SetFont('Times','',9.5);
+		$this->Cell(81,5,'SIMENS+: www.simens.sn',0,0,'R',false);
+	}
+	
+	protected $B = 0;
+	protected $I = 0;
+	protected $U = 0;
+	protected $HREF = '';
+	
+	function WriteHTML($html)
+	{
+		// Parseur HTML
+		$html = str_replace("\n",' ',$html);
+		$a = preg_split('/<(.*)>/U',$html,-1,PREG_SPLIT_DELIM_CAPTURE);
+		foreach($a as $i=>$e)
+		{
+			if($i%2==0)
+			{
+				// Texte
+				if($this->HREF)
+					$this->PutLink($this->HREF,$e);
+				else
+					$this->Write(5,$e);
+			}
+			else
+			{
+				// Balise
+				if($e[0]=='/')
+					$this->CloseTag(strtoupper(substr($e,1)));
+				else
+				{
+					// Extraction des attributs
+					$a2 = explode(' ',$e);
+					$tag = strtoupper(array_shift($a2));
+					$attr = array();
+					foreach($a2 as $v)
+					{
+						if(preg_match('/([^=]*)=["\']?([^"\']*)/',$v,$a3))
+							$attr[strtoupper($a3[1])] = $a3[2];
+					}
+					$this->OpenTag($tag,$attr);
+				}
+			}
+		}
+	}
+	
+	function OpenTag($tag, $attr)
+	{
+		// Balise ouvrante
+		if($tag=='B' || $tag=='I' || $tag=='U')
+			$this->SetStyle($tag,true);
+		if($tag=='A')
+			$this->HREF = $attr['HREF'];
+		if($tag=='BR')
+			$this->Ln(5);
+	}
+	
+	function CloseTag($tag)
+	{
+		// Balise fermante
+		if($tag=='B' || $tag=='I' || $tag=='U')
+			$this->SetStyle($tag,false);
+		if($tag=='A')
+			$this->HREF = '';
+	}
+	
+	function SetStyle($tag, $enable)
+	{
+		// Modifie le style et sélectionne la police correspondante
+		$this->$tag += ($enable ? 1 : -1);
+		$style = '';
+		foreach(array('B', 'I', 'U') as $s)
+		{
+			if($this->$s>0)
+				$style .= $s;
+		}
+		$this->SetFont('',$style);
+	}
+	
+	function PutLink($URL, $txt)
+	{
+		// Place un hyperlien
+		$this->SetTextColor(0,0,255);
+		$this->SetStyle('U',true);
+		$this->Write(5,$txt,$URL);
+		$this->SetStyle('U',false);
+		$this->SetTextColor(0);
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	protected $tabInformations ;
+	protected $nomService;
+	protected $infosComp;
+	protected $PeriodePrelevement;
+
+	public function setTabInformations($tabInformations)
+	{
+		$this->tabInformations = $tabInformations;
+	}
+	
+	public function getTabInformations()
+	{
+		return $this->tabInformations;
+	}
+	
+	public function getNomService()
+	{
+		return $this->nomService;
+	}
+	
+	public function setNomService($nomService)
+	{
+		$this->nomService = $nomService;
+	}
+	
+	public function getPeriodePrelevement()
+	{
+		return $this->PeriodePrelevement;
+	}
+	
+	public function setPeriodePrelevement($PeriodePrelevement)
+	{
+		$this->PeriodePrelevement = $PeriodePrelevement;
+	}
+
+	public function getInfosComp()
+	{
+		return $this->infosComp;
+	}
+	
+	public function setInfosComp($infosComp)
+	{
+		$this->infosComp = $infosComp;
+	}
+	
+	
+	protected $infosPatients;
+	protected $motifExamenDem;
+	protected $typeExamen;
+	protected $idExamen;
+	protected $libelleExamen;
+	
+	
+	public function getInfosPatients()
+	{
+		return $this->infosPatients;
+	}
+	
+	public function setInfosPatients($infosPatients)
+	{
+		$this->infosPatients = $infosPatients;
+	}
+	
+	public function getMotifExamenDem()
+	{
+		return $this->motifExamenDem;
+	}
+	
+	public function setMotifExamenDem($motifExamenDem)
+	{
+		$this->motifExamenDem = $motifExamenDem;
+	}
+	
+	public function getTypeExamen()
+	{
+		return $this->typeExamen;
+	}
+	
+	public function setTypeExamen($typeExamen)
+	{
+		$this->typeExamen = $typeExamen;
+	}
+	
+	public function getIdExamen()
+	{
+		return $this->idExamen;
+	}
+	
+    public function setIdExamen($idExamen)
+	{
+		$this->idExamen = $idExamen;
+	}
+	
+	public function getLibelleExamen()
+	{
+		return $this->libelleExamen;
+	}
+	
+	public function setLibelleExamen($libelleExamen)
+	{
+		$this->libelleExamen = $libelleExamen;
+	}
+	
+	
+	protected function nbJours($debut, $fin) {
+		//60 secondes X 60 minutes X 24 heures dans une journee
+		$nbSecondes = 60*60*24;
+	
+		$debut_ts = strtotime($debut);
+		$fin_ts = strtotime($fin);
+		$diff = $fin_ts - $debut_ts;
+		return ($diff / $nbSecondes);
+	}
+	
+	function EnTetePage()
+	{
+		$this->SetFont('Times','',10.3);
+		$this->SetTextColor(0,0,0);
+		$this->Cell(0,4,"République du Sénégal");
+		$this->SetFont('Times','',8.5);
+		$this->Cell(0,4,"",0,0,'R');
+		$this->SetFont('Times','',10.3);
+		$this->Ln(5.4);
+		$this->Cell(100,4,"Ministère de la santé et de l'action sociale");
+		
+		$this->AddFont('timesbi','','timesbi.php');
+		$this->Ln(5.4);
+		$this->Cell(100,4,"C.E.R.P.A.D de Saint-louis");
+		$this->Ln(5.4);
+		$this->SetFont('timesbi','',10.3);
+		$this->Cell(14,4,"Service : ",0,0,'L');
+		$this->SetFont('Times','',10.3);
+		$this->Cell(86,4,$this->getNomService(),0,0,'L');
+		
+		$this->Ln(6);
+		$this->SetFont('Times','',13);
+		$this->SetTextColor(0,128,0);
+		$this->Cell(0,-3,"DEMANDE D'EXAMENS",0,0,'C');
+		$this->Ln(1);
+		$this->SetFont('Times','',12.3);
+		$this->SetFillColor(0,128,0);
+		$this->Cell(0,0.3,"",0,1,'C',true);
+	
+		// EMPLACEMENT DU LOGO
+		// EMPLACEMENT DU LOGO
+		$baseUrl = $_SERVER['SCRIPT_FILENAME'];
+		$tabURI  = explode('public', $baseUrl);
+		$this->Image($tabURI[0].'public/images_icons/CERPAD_UGB_LOGO_M.png', 162, 12, 35, 22);
+		
+		// EMPLACEMENT DES INFORMATIONS SUR LE PATIENT
+		// EMPLACEMENT DES INFORMATIONS SUR LE PATIENT
+		$infoPatients = $this->getInfosPatients();
+		$this->SetFont('Times','B',8.5);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(1);
+		$this->Cell(90,4,"PRENOM ET NOM :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(92,4,iconv ('UTF-8' , 'windows-1252', $infoPatients->prenom).' '.iconv ('UTF-8' , 'windows-1252', $infoPatients->nom),0,0,'L'); }
+		
+		$this->SetFont('Times','B',8.5);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(5);
+		$this->Cell(90,4,"SEXE :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(92,4,iconv ('UTF-8' , 'windows-1252', $infoPatients->sexe),0,0,'L'); }
+		
+		//GESTION DES AGES
+		//GESTION DES AGES
+		$age = $infoPatients->age;
+		$aujourdhui = (new \DateTime() ) ->format('Y-m-d');
+		if(!$age){
+		
+			$age_jours = $this->nbJours($infoPatients->date_naissance, $aujourdhui);
+			if($age_jours < 31) {
+				$age = $age_jours." jours";
+			}
+			else
+			if($age_jours >= 31) {
+				$nb_mois = (int)($age_jours/30);
+				$nb_jours = $age_jours - ($nb_mois*30);
+				$age = $nb_mois."m ".$nb_jours."j";
+			}
+		
+		}else{
+		
+			$age = $age." ans";
+		
+		}
+		
+		$convertDate = new DateHelper();
+		
+		$this->SetFont('Times','B',8.5);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(5);
+		$this->Cell(90,4,"DATE DE NAISSANCE (age) :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(92,4, $convertDate->convertDate($infoPatients->date_naissance).' ('.$age.')',0,0,'L'); }
+		
+		$this->SetFont('Times','B',8.5);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(5);
+		$this->Cell(90,4,"TELEPHONE :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(72,4,$infoPatients->telephone,0,0,'L'); }
+		
+		$this->Ln(5);
+		$this->SetFillColor(0,128,0);
+		$this->Cell(0,0.3,"",0,1,'C',true);
+		
+		$this->Ln(2);
+		$this->AddFont('timesi','','timesi.php');
+		$this->SetFont('timesi','',8);
+		$this->Cell(183,1,"Imprimé le : ".$convertDate->convertDate($aujourdhui),0,1,'R');
+	}
+	
+	public function moisEnLettre($mois){
+		$lesMois = array('','Janvier','Fevrier','Mars','Avril',
+				'Mais','Juin','Juillet','Aout','Septembre','Octobre','Novembre','Decembre');
+		return $lesMois[$mois];
+	}
+	
+	function CorpsDocument()
+	{
+		$this->AddFont('zap','','zapfdingbats.php');
+		$this->AddFont('timesb','','timesb.php');
+		$this->AddFont('timesi','','timesi.php');
+		$this->AddFont('times','','times.php');
+
+		$motifExamenDem = $this->getMotifExamenDem();
+		$typeExamen = $this->getTypeExamen();
+		$idExamen = $this->getIdExamen();
+		$libelleExamen = $this->getLibelleExamen();
+		$this->Ln(2);
+		
+		//AFFICHAGE DE L'EXAMEN DEMANDE
+		//AFFICHAGE DE L'EXAMEN DEMANDE
+		$this->SetFillColor(249,249,249);
+		$this->SetDrawColor(220,220,220);
+		$this->SetFont('zap','',11.3);
+		$this->Cell(3,7,'o','BT',0,'C',1);
+		
+		$this->SetFont('times','',12);
+		$this->Cell(180,7,'Examen demandé : ','BT',1,'L',1);
+		
+		$this->SetFont('zap','',11.3);
+		$this->Cell(10,9,'','',0,'C');
+		$this->Cell(3,9,'+','',0,'C');
+		$this->SetFont('timesi','',11);
+		$this->Cell(170,9, iconv ('UTF-8' , 'windows-1252', ' '.$libelleExamen),'',1,'L',0);
+		
+		//AFFICHAGE DU MOTIF DE L'EXAMEN
+		//AFFICHAGE DU MOTIF DE L'EXAMEN
+		$this->Ln(2);
+		$this->SetFillColor(249,249,249);
+		$this->SetDrawColor(220,220,220);
+		$this->SetFont('zap','',11.3);
+		$this->Cell(3,7,'o','BT',0,'C',1);
+		
+		$this->SetFont('times','',12);
+		$this->Cell(180,7,"Motif de l'examen : ",'BT',1,'L',1);
+		
+		$this->SetFont('zap','',11.3);
+		$this->Cell(3,8,'','',0,'C');
+		$this->SetFont('timesi','',11);
+		$this->MultiCell(180,8, iconv ('UTF-8' , 'windows-1252', ' '.$motifExamenDem),'','L',0);
+		
+	}
+	
+	//IMPRESSION DES INFOS STATISTIQUES
+	//IMPRESSION DES INFOS STATISTIQUES
+	function impressionUnExamenDemande()
+	{
+		$this->AddPage();
+		$this->EnTetePage();
+		$this->CorpsDocument();
+	}
+
+}
+
+?>

--- a/module/Consultation/view/consultation/consultation/consulter.phtml
+++ b/module/Consultation/view/consultation/consultation/consulter.phtml
@@ -21,6 +21,8 @@ echo $this->headLink()->appendStylesheet($this->basePath().'/css/consultation/co
 echo $this->headLink()->appendStylesheet($this->basePath().'/css/monstyle.css');
 ?>
       
+<?php echo $this->headLink()->appendStylesheet($this->basePath().'/js/plugins/dateTimePicker/jquery-ui-timepicker-addon.css');?>
+<?php echo $this->headScript()->appendFile($this->basePath().'/js/plugins/dateTimePicker/jquery-ui-timepicker-addon.js');?>
 
 <script>
 //POUR LE MENU GAUCHE dans -elementgauche.phtml
@@ -1691,13 +1693,26 @@ echo $this->form()->openTag($form); ?>
            <div style='font-family: police2;font-size: 17px; font-weight: bold;'> Transfert </div>
            <div>
 
+              <table id="transfert" style="width: 100%;">
+                 <tr class="form-transfert" style="width: 100%;">
+                    <th style="width: 45%;"><?php echo $this->formRow($form->get('motifTransfert'));?></th>
+                    <th style="width: 27%;"><?php echo $this->formRow($form->get('hopitalAccueil'));?></th>
+                    <th style="width: 28%;"><?php echo $this->formRow($form->get('serviceAccueil'));?></th>
+                 </tr>
+              </table>
+              
            </div>
 
          <!-- ************** Hospitalisation **************** -->
          <!-- **2** -->
-           <div style='font-family: police2;font-size: 17px; font-weight: bold;'> Hospitalisation</div>
+           <div style='font-family: police2;font-size: 17px; font-weight: bold;'> Hospitalisation de jour</div>
            <div style="max-height:300px;">
                                
+             <table id="hospitalisation" style="width: 73%;">
+               <tr>
+                  <th class="form-hospitalisation" style="width: 60%;"> <?php echo $this->formRow($form->get('motifHospitalisation'));?> </th>
+               </tr>
+             </table>
                                     
            </div>
                                 
@@ -1707,6 +1722,42 @@ echo $this->form()->openTag($form); ?>
            <div style='font-family: police2;font-size: 17px; font-weight: bold;'> Rendez-vous</div>
            <div>
 
+             <table id="rendezvous" style="width: 100%;">
+               <tr class="form-rendezvous" style="width: 100%; vertical-align: top; " >
+                 
+                 <th class="form-rendezvous" style="width: 27%;"> <?php echo $this->formRow($form->get('dateHeureRendezVous')); ?> </th>
+                 <th style="width: 7%;"> </th>
+                 
+                 <th style="width: 56%;"> 
+                   <table style="width: 100%;">
+                     <tr style="width: 100%;">
+                       <td> <label>Motif</label> </td>
+                     </tr>
+                     <tr style="width: 100%;">
+                       <td style="width: 100%; border-top-right-radius: 10px;"> 
+                         <table id="rendezvousPreciserVSS" style="width: 90%; background: #eeeeee;"> 
+                           <tr style="height: 35px; font-size: 14px; border-top-right-radius: 10px; font-family: times new roman;">
+                             <td style="width: 50%; padding-left: 10px;" ><input id="rendervousLabelVSInput" type= "radio"  name="rendezvousPreciserVSSoin" value="1"> <span id="rendervousLabelVS" style="cursor: pointer; margin-top: 10px;"> Visite syst&eacute;matique </span> </td>
+                             <td style="width: 25%; padding-left: 10px;" ><input id="rendervousLabelSInput"  type= "radio"  name="rendezvousPreciserVSSoin" value="2"> <span id="rendervousLabelS"  style="cursor: pointer;"> Soin  </span></td>
+                             <td style="width: 25%; padding-left: 10px;" ><input id="rendervousLabelAInput"  type= "radio"  name="rendezvousPreciserVSSoin" value="3"> <span id="rendervousLabelA"  style="cursor: pointer;"> Autre </span></td>
+                           </tr>
+                         </table>
+                       </td>
+                     </tr>
+                     <tr style="width: 100%;">
+                       <td> <?php echo $this->formRow($form->get('motifRendezVous'));?> </td>
+                     </tr>
+                   </table>
+                 </th>
+
+                 <th style="width: 10%;"><th>
+                 
+                 <script> initChampDateTimeEtMotifRendezVousForm(); </script>
+               </tr>
+                                        
+             </table>
+           
+           
            </div>
          </div>
 
@@ -1737,7 +1788,7 @@ echo $this->form()->openTag($form); ?>
    </p>
 </div>
 
-
+<div id="sauverLesInfosDesExamensRadioBioSaisisPopup" style="display: none;"></div>
 
 <?php echo $this->form()->closeTag();?>
 </div>
@@ -1754,13 +1805,30 @@ $("#annuler2").click(function() {
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 <!-- POP UP pour Ajouter les résultats d'une analyse -->
 <div id="imprimerDesDemandesExamensAvecSaisiMotifs" title="Imprimer les demandes d'examens (Renseigner les motifs des examens)" style="display: none;"  align="center">
     <div id="contenuimprimerDesDemandesExamensAvecSaisiMotifs" style="width: 97%;"> 
       <table style="height: 50px; width: 100%;" id="contenuExamRadioDemImprime_0">
         <tr style="width: 100%">
            <td class="titreZoneInfosStylePop" >
-           &#10049; Examens Radiologiques <img onclick="imprimerTousLesExamensDemandesPop();" style="float: right; width: 25px; height: 25px; cursor: pointer;" src="../images_icons/pdf.png"  title="Imprimer tous" >  
+           &#10049; Examens Radiologiques <img onclick="imprimerTousLesExamensRadioDemandesPop();" style="float: right; width: 25px; height: 25px; cursor: pointer;" src="../images_icons/pdf.png"  title="Imprimer tous" >  
            <div style="width: 100%; border: 1px solid green;"> </div>
            </td>
         </tr>
@@ -1769,12 +1837,11 @@ $("#annuler2").click(function() {
       <table style="height: 50px; width: 100%;" id="contenuExamBioDemImprime_0">
         <tr style="width: 100%">
            <td class="titreZoneInfosStylePop" >
-           <span style="font-size: 20px;">&#10049;</span> Examens Biologiques <img onclick="imprimerTousLesExamensBioDemandesPop();" style="float: right; width: 25px; height: 25px; cursor: pointer;" src="../images_icons/pdf.png"  title="Imprimer tous" >  
+           &#10049; Examens Biologiques  <img onclick="imprimerTousLesExamensBioDemandesPop(); return false;" style="float: right; width: 25px; height: 25px; cursor: pointer;" src="../images_icons/pdf.png"  title="Imprimer tous" >  
            <div style="width: 100%; border: 1px solid green;"> </div>
            </td>
         </tr>
       </table>
-      
     </div>
     
     <div style="display: none;" id="codePourAjouterDesExamensDemandesAImprimer">
@@ -1797,7 +1864,7 @@ $("#annuler2").click(function() {
 				    <label> 
 				      &#129091; <i style="font-size: 16px;">  Motif de l'examen </i> <span id="imageImpressionExamenPopPrecis"> </span>
 				      <input type="hidden" >
-				      <textarea style="width: 100%; max-width: 475px;  min-width: 475px; height: 120px; max-height: 90px; min-height: 90px;"> </textarea> 
+				      <textarea style="width: 100%; max-width: 475px;  min-width: 475px; height: 120px; max-height: 90px; min-height: 90px; maxlength: 200;"> </textarea> 
 				    </label>
 		          </th>
 		        </tr>
@@ -1811,6 +1878,30 @@ $("#annuler2").click(function() {
 <form id="formulaireExamensDemandesPopup" style="display: none;">
    <button id="imprimerExamensDemandesPopup" > </button>
 </form>
+
+<form id="formulaireExamensBioDemandesPopup" style="display: none;">
+   <button id="imprimerExamensBioDemandesPopup" > </button>
+</form>
+
+<form id="formulaireUnExamenDemandePopup" style="display: none;">
+   <button id="imprimerUnExamenDemandePopup" > </button>
+</form>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/module/Consultation/view/consultation/consultation/modifier-consultation.phtml
+++ b/module/Consultation/view/consultation/consultation/modifier-consultation.phtml
@@ -1321,10 +1321,11 @@ echo $this->form()->openTag($form); ?>
                 <?php echo  $this->headScript()->appendFile($this->basePath().'/js/consultation/ajoutDemandesAnalyses.js'); ?>
                 <div id='montantTotal' style='height: 15; cursor: pointer; float:right; margin-top: -5px;'> 
                     <span style='padding-left: 20px; color: green; font-size: 17px; font-family: times new roman;'> </span>
-                    <hass> <a href="javascript:imprimerAnalyse();" >
-                           <img style="margin-top: -6px; float: right; cursor: pointer; height: 19px; width: 19px;" src="../images_icons/pdf.png"  title="Imprimer" />
-                           </a> 
-                     </hass> 
+                   
+                    <img onclick="effectuerDesDemandesExamens();" style="margin-top: -5px; float: left; cursor: pointer; height: 19px; width: 19px;" src="../images_icons/detailsd.png"  title="Demandes d'examens" />
+                    <a href="javascript:imprimerAnalyse();" >
+                      <img style="margin-top: -6px; float: right; cursor: pointer; height: 19px; width: 19px;" src="../images_icons/pdf.png"  title="Imprimer" />
+                    </a> 
                 </div>
                 
                 <div id="lesDemandesExamens" style="width: 100%; height:300px;">
@@ -1372,19 +1373,15 @@ echo $this->form()->openTag($form); ?>
             <!--**************** RESULTAT DES AUTRES EXAMENS *******************-->
             <!--**************** RESULTAT DES AUTRES EXAMENS *******************-->
             <div style='font-family: police2;font-size: 17px; font-weight: bold;'> R&eacute;sultats </div>
-            <div style='max-height: 200px;'>
+            <div style='max-height: 300px;'>
             
-               <div class="titreZoneInfosEAFStyle">&#10049; Renseigner les r&eacute;sultats des examens (radiologie) demand&eacute;s</div>
-		         <div class="zoneInfosStyle contenuResultatsExamensDemandesStyle">
+               <div class="titreZoneInfosEAFStyle">&#10049; Renseigner les r&eacute;sultats des examens radiologiques demand&eacute;s</div>
+		         <div class="zoneInfosStyle titreResultatExamenRadioStyle" id="contenuResultatExamenRadio">
+
 		            <table style="width:100%;">
-		              
-		              <!-- LIGNE N°1 -->
-					  <tr style="height:40px; width:100%;" >
-					     <th style="width:100%; padding-right: 25px; vertical-align: top;"> 
-		                      <div style="float:left; width: 100%;" id="idResultatExamComp1" ><label style="width: 100%; height:30px; text-align:left;" ><span style='font-size: 12px;'>&#11166; </span><span> R&eacute;sultat : </span> <textarea style='width: 90%; min-width: 90%; max-width: 90%; height: 85px; min-height: 85px; max-height: 85px;  '> </textarea> </label></div> 
-						 </th>
-				      </tr>
-				    </table>
+		              <tr id="contenuResultExamen1"></tr>
+                    </table>
+				    
 				 </div>
 
             </div>
@@ -1648,21 +1645,6 @@ echo $this->form()->openTag($form); ?>
 				      </div>
 				    </div>
 				    
-                    <!--********************* BOUTON VALIDER OU MODIFIER ************************-->
-                    <!--********************* BOUTON VALIDER OU MODIFIER ************************-->
-                    <table style="width: 90%; float:right; position: relative; right: 0;">
-                        <tr style="width: 100%;">
-                          <th style="height:15px;">
-                             <div id='bouton_Medicament_modifier_demande' style="float:right;">
-                               <button >Modifier</button>
-                             </div>
-                             <div id='bouton_Medicament_valider_demande' style="float:right;">
-                               <button >Valider</button>
-                             </div>
-                          </th>
-                        </tr>
-                    </table>
-				          
      		     </div>
      		     
      		     <!--********************* CHARGEMENT DES DONNEES  ************************-->
@@ -1762,7 +1744,20 @@ echo $this->form()->openTag($form); ?>
         </p>
       </div>
 
-
+      <!-- Afficher la liste des motifs des examens radio demandes -->
+      <!-- Afficher la liste des motifs des examens radio demandes -->
+      <?php $listeMotifsExamensRadioDemandes = $this->motifsExamensRadioDemandes; ?>
+      <?php for($i = 0 ; $i < count($listeMotifsExamensRadioDemandes) ; $i++){ ?>
+      <script> tabDonneesMotifsDesExamensRadioSauvegardees[<?php echo $listeMotifsExamensRadioDemandes[$i][0]; ?>] = "<?php echo $listeMotifsExamensRadioDemandes[$i][1]; ?>"; </script>
+      <?php } ?>
+      
+      <?php $listeMotifsExamensBioDemandes = $this->motifsExamensBioDemandes; ?>
+      <?php for($i = 0 ; $i < count($listeMotifsExamensBioDemandes) ; $i++){ ?>
+      <script> tabDonneesMotifsDesExamensSauvegardees[<?php echo $listeMotifsExamensBioDemandes[$i][0]; ?>] = "<?php echo $listeMotifsExamensBioDemandes[$i][1]; ?>"; </script>
+      <?php } ?>
+      
+      <div id="sauverLesInfosDesExamensRadioBioSaisisPopup" style="display: none;"></div>
+      
 <?php echo $this->form()->closeTag();?>
 </div>
 
@@ -1775,6 +1770,84 @@ $("#annuler2").click(function() {
 }); 
 </script>
 
+
+<!-- POP UP pour Ajouter les résultats d'une analyse -->
+<div id="imprimerDesDemandesExamensAvecSaisiMotifs" title="Imprimer les demandes d'examens (Renseigner les motifs des examens)" style="display: none;"  align="center">
+    <div id="contenuimprimerDesDemandesExamensAvecSaisiMotifs" style="width: 97%;"> 
+      <table style="height: 50px; width: 100%;" id="contenuExamRadioDemImprime_0">
+        <tr style="width: 100%">
+           <td class="titreZoneInfosStylePop" >
+           &#10049; Examens Radiologiques <img onclick="imprimerTousLesExamensRadioDemandesPop();" style="float: right; width: 25px; height: 25px; cursor: pointer;" src="../images_icons/pdf.png"  title="Imprimer tous" >  
+           <div style="width: 100%; border: 1px solid green;"> </div>
+           </td>
+        </tr>
+      </table>
+      
+      <table style="height: 50px; width: 100%;" id="contenuExamBioDemImprime_0">
+        <tr style="width: 100%">
+           <td class="titreZoneInfosStylePop" >
+           &#10049; Examens Biologiques  <img onclick="imprimerTousLesExamensBioDemandesPop(); return false;" style="float: right; width: 25px; height: 25px; cursor: pointer;" src="../images_icons/pdf.png"  title="Imprimer tous" >  
+           <div style="width: 100%; border: 1px solid green;"> </div>
+           </td>
+        </tr>
+      </table>
+    </div>
+    
+    <div style="display: none;" id="codePourAjouterDesExamensDemandesAImprimer">
+      <table style="width: 100%; height: 120px;" class="contenuExamDemImprime">
+        <tr>
+          <td style="width: 40%;" >
+             <table style="height: 50px; width: 95%; float: left;"  class="contenuZoneInfosStylePopDemExam zoneInfosStyle designHistoireMaladie" >
+		        <tr style="width: 100%;">
+		          <th style="width: 100%; padding-right: 25px; vertical-align: top;"> 
+				    <div style="float:left; width: 100%;" > <label style="width: 98%; margin-top: 3.5px; margin-left: 4px; height:30px; text-align:left;" ><span style='font-size: 12px;'> &#11166; </span> <span class='libelleExamenDemandeAImprimer'  style='font-size: 13px;'> Radiologie </span> </label></div> 
+		          </th>
+		        </tr>
+		      </table>
+          </td>
+		      
+		  <td style="width: 60%; ">    
+		     <table style="height: 50px; width: 100%; float: left;"  class="contenuZoneInfosStylePopDemExam zoneInfosStyle designHistoireMaladie" >
+		        <tr style="width: 100%;">
+		          <th style="width:100%; padding-right: 6px; padding-left: 6px; padding-top: 4px; padding-bottom: 3px; vertical-align: top;" class="textareaBaliseSaisiMotifExamen"> 
+				    <label> 
+				      &#129091; <i style="font-size: 16px;">  Motif de l'examen </i> <span id="imageImpressionExamenPopPrecis"> </span>
+				      <input type="hidden" >
+				      <textarea style="width: 100%; max-width: 475px;  min-width: 475px; height: 120px; max-height: 90px; min-height: 90px; maxlength: 200;"> </textarea> 
+				    </label>
+		          </th>
+		        </tr>
+		      </table>
+		  </td>
+        </tr>
+      </table>
+    </div>
+</div>
+
+<form id="formulaireExamensDemandesPopup" style="display: none;">
+   <button id="imprimerExamensDemandesPopup" > </button>
+</form>
+
+<form id="formulaireExamensBioDemandesPopup" style="display: none;">
+   <button id="imprimerExamensBioDemandesPopup" > </button>
+</form>
+
+<form id="formulaireUnExamenDemandePopup" style="display: none;">
+   <button id="imprimerUnExamenDemandePopup" > </button>
+</form>
+
+
+
+
+
+
+
+
+
+
+<form id="formulaireImprimerOrdonnance" style="display: none;">
+   <button id="imprimerOrdonnance" > </button>
+</form>
 
 <form id="formulaireImprimerDemandesAnalyses" style="display: none;">
    <button id="imprimerDemandesAnalyses" > </button>

--- a/module/Facturation/src/Facturation/Model/FacturationTable.php
+++ b/module/Facturation/src/Facturation/Model/FacturationTable.php
@@ -6,6 +6,7 @@ use Zend\Db\TableGateway\TableGateway;
 use Zend\Db\Sql\Sql;
 use Zend\Db\Sql\Predicate\In;
 use Zend\Crypt\PublicKey\Rsa\PublicKey;
+use Infirmerie\View\Helper\DateHelper;
 
 class FacturationTable {
 	protected $tableGateway;
@@ -306,4 +307,149 @@ class FacturationTable {
  	}
  	
  	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	
+ 	//Utiliser dans le module de la consultation
+ 	//Utiliser dans le module de la consultation
+ 	public function deleteMotifsExamensRadio($idcons){
+ 		$db = $this->tableGateway->getAdapter();
+ 		$sql = new Sql($db);
+ 		$sQuery = $sql->delete()->from('motif_examens_radio_demandes')->where(array('idcons' => $idcons));
+ 		$sql->prepareStatementForSqlObject($sQuery)->execute();
+ 	}
+ 	
+ 	
+ 	public function addMotifsExamensRadioDemandes($tabDonnees, $idemploye){
+ 		$this->deleteMotifsExamensRadio($tabDonnees['idcons']);
+ 		
+ 		$db = $this->tableGateway->getAdapter();
+ 		$sql = new Sql($db);
+ 		$nbExamenRadio = $tabDonnees['nbExamenRadio'];
+ 		
+ 		for($i = 0 ; $i < $nbExamenRadio ;  $i++){
+ 			$donnee = array('idcons' => $tabDonnees['idcons'], 'idexamen' => $tabDonnees['idExamenRadio_'.$i], 'motif' => $tabDonnees['motifExamenRadio_'.$i], 'idemploye' => $idemploye);
+ 			$sQuery = $sql->insert()->into('motif_examens_radio_demandes')->values($donnee);
+ 			$sql->prepareStatementForSqlObject($sQuery)->execute();
+ 		}
+ 	
+ 	}
+ 	
+ 	
+ 	public function deleteMotifsExamensBio($idcons){
+ 		$db = $this->tableGateway->getAdapter();
+ 		$sql = new Sql($db);
+ 		$sQuery = $sql->delete()->from('motif_examens_bio_demandes')->where(array('idcons' => $idcons));
+ 		$sql->prepareStatementForSqlObject($sQuery)->execute();
+ 	}
+ 	
+ 	
+ 	public function addMotifsExamensBioDemandes($tabDonnees, $idemploye){
+ 		$this->deleteMotifsExamensBio($tabDonnees['idcons']);
+ 		
+ 		$db = $this->tableGateway->getAdapter();
+ 		$sql = new Sql($db);
+ 		$nbExamenBio = $tabDonnees['nbExamenBio'];
+ 			
+ 		for($i = 0 ; $i < $nbExamenBio ;  $i++){
+ 			$donnee = array('idcons' => $tabDonnees['idcons'], 'idexamen' => $tabDonnees['idExamenBio_'.$i], 'motif' => $tabDonnees['motifExamenBio_'.$i], 'idemploye' => $idemploye);
+ 			$sQuery = $sql->insert()->into('motif_examens_bio_demandes')->values($donnee);
+ 			$sql->prepareStatementForSqlObject($sQuery)->execute();
+ 		}
+ 	
+ 	}
+ 	
+ 	
+ 	public function getMotifsExamensRadioDemandes($idcons){
+ 		$db = $this->tableGateway->getAdapter();
+ 		$sql = new Sql($db);
+ 		$sQuery = $sql->select()->from('motif_examens_radio_demandes')->where(array('idcons' => $idcons));
+ 		$resultat = $sql->prepareStatementForSqlObject($sQuery)->execute();
+ 		
+ 		$listeMotifs = array();
+ 		foreach ($resultat as $result){
+ 			$listeMotifs[] = array($result['idexamen'], $result['motif']);
+ 		}
+ 		return $listeMotifs;
+ 	}
+ 	
+ 	
+ 	public function getMotifsExamensBioDemandes($idcons){
+ 		$db = $this->tableGateway->getAdapter();
+ 		$sql = new Sql($db);
+ 		$sQuery = $sql->select()->from('motif_examens_bio_demandes')->where(array('idcons' => $idcons));
+ 		$resultat = $sql->prepareStatementForSqlObject($sQuery)->execute();
+ 			
+ 		$listeMotifs = array();
+ 		foreach ($resultat as $result){
+ 			$listeMotifs[] = array($result['idexamen'], $result['motif']);
+ 		}
+ 		return $listeMotifs;
+ 	}
+ 	
+ 	
+ 	public function deleteRendezVous($idcons){
+ 		$db = $this->tableGateway->getAdapter();
+ 		$sql = new Sql($db);
+ 		$sQuery = $sql->delete()->from('rendez_vous_cons')->where(array('idcons' => $idcons));
+ 		$sql->prepareStatementForSqlObject($sQuery)->execute();
+ 	}
+ 	
+ 	
+ 	public function addRendezVous($tabDonnees, $idemploye){
+
+ 		$dateRendezvous = $tabDonnees['dateHeureRendezVous'];
+ 		$Convert = new DateHelper();
+ 		$DateRv = $Convert->convertDateInAnglais($Convert->decouperDateInDatepicker($dateRendezvous));
+ 		$HeureRv = $Convert->decouperHeureInDatepicker($dateRendezvous);
+ 		$motifRendezVous = $tabDonnees['motifRendezVous'];
+ 		
+ 		$donneesRV = array(
+ 				'idcons'    => $tabDonnees['idcons'], 
+ 				'dateRv'    => $DateRv,
+ 				'heureRv'   => $HeureRv,
+ 				'motifRv'   => $motifRendezVous,
+ 				'idemploye' => $idemploye,
+ 		);
+ 		
+ 		$this->deleteRendezVous($tabDonnees['idcons']);
+ 		
+ 		$db = $this->tableGateway->getAdapter();
+ 		$sql = new Sql($db);
+ 		$sQuery = $sql->insert()->into('rendez_vous_cons')->values($donneesRV);
+ 		$sql->prepareStatementForSqlObject($sQuery)->execute();
+ 	}
+ 	
+ 	
 }
+

--- a/module/Facturation/view/facturation/facturation/admission.phtml
+++ b/module/Facturation/view/facturation/facturation/admission.phtml
@@ -144,6 +144,8 @@ initialisation();
                 </div>
                 <div style='width: 40%;'></div>
           </div>
+          
+          <button id="envoyerDonneesAdmission" style=" height:35px; dispaly: none; "></button>
           <?php echo $this->form()->closeTag(); ?>
 		  
     </div>

--- a/module/Infirmerie/src/Infirmerie/Model/DemandeAnalyseTable.php
+++ b/module/Infirmerie/src/Infirmerie/Model/DemandeAnalyseTable.php
@@ -17,6 +17,7 @@ class DemandeAnalyseTable {
  			$select->join('patient' , 'patient.idpersonne = depistage.idpatient' , array('*'));
  			$select->join('personne' , 'personne.idpersonne = patient.idpersonne' , array('date_naissance'));
  			$select->order('date_naissance asc');
+ 			$select->where(array('demande_analyse.idanalyse' => 68));
  		})->toArray();
  	}
  	
@@ -29,6 +30,7 @@ class DemandeAnalyseTable {
  			$select->where(array(
 					'date_naissance >= ?' => $date_debut,
 					'date_naissance <= ?' => $date_fin,
+ 					'demande_analyse.idanalyse' => 68
 			));
  		})->toArray();
  	}
@@ -39,6 +41,7 @@ class DemandeAnalyseTable {
  			$select->join('patient' , 'patient.idpersonne = depistage.idpatient' , array('*'));
  			$select->join('personne' , 'personne.idpersonne = patient.idpersonne' , array('date_naissance'));
  			$select->order('date_naissance asc');
+ 			$select->where(array('demande_analyse.idanalyse' => 68));
  		})->toArray();
  		
  		$tabDateNaissance = array();

--- a/module/Infirmerie/src/Infirmerie/View/Helper/DateHelper.php
+++ b/module/Infirmerie/src/Infirmerie/View/Helper/DateHelper.php
@@ -41,6 +41,17 @@ class DateHelper extends AbstractHelper{
 		$time = substr($dateTime, 11, 8);
 		return $time;
 	}
+	
+	public function decouperDateInDatepicker ($dateTime) {
+		$time = substr($dateTime, 0, 10);
+		return $time;
+	}
+	
+	public function decouperHeureInDatepicker ($dateTime) {
+		$time = substr($dateTime, 13, 5);
+		return $time;
+	}
+	
 	/*
 	 * La date est au format : dd/MM/yyyy
 	*/

--- a/module/Laboratoire/src/Laboratoire/Controller/BiologisteController.php
+++ b/module/Laboratoire/src/Laboratoire/Controller/BiologisteController.php
@@ -12,6 +12,7 @@ use Secretariat\View\Helper\ResultatsAnalysesDemandeesPdf;
 use Secretariat\View\Helper\DocumentResultatsPdf;
 use Secretariat\View\Helper\ResultatsNfsPdf;
 use Secretariat\View\Helper\ResultatsTypageHemoglobinePdf;
+use Laboratoire\View\Helper\ImprimerResultatsAnalysesDemandees;
 
 class BiologisteController extends AbstractActionController {
 	protected $personneTable;
@@ -1524,6 +1525,7 @@ class BiologisteController extends AbstractActionController {
  	        	$('#type_materiel_goutte_epaisse').val('".str_replace( "'", "\'",$resultat['type_materiel'])."');
 	            $('#goutte_epaisse').val('".$resultat['goutte_epaisse']."');
 	            if('".$resultat['goutte_epaisse']."' == 'Positif'){ $('#goutte_epaisse_positif').toggle(true); $('#densite_parasitaire').val('".$resultat['densite_parasitaire']."'); }
+	            $('.ER_".$iddemande." #commentaire_goutte_epaisse').val('".str_replace( "'", "\'",$resultat['commentaire_goutte_epaisse'])."');		
 	        </script>";
 	    }
 	    return $html;
@@ -1662,6 +1664,7 @@ class BiologisteController extends AbstractActionController {
 	        "<script>
 	        	$('#type_materiel_azotemie').val('".str_replace( "'", "\'", $resultat['type_materiel'])."');		
 	            $('#uree_sanguine').val('".$resultat['valeur']."');
+	            $('#uree_sanguine_mmol').val('".$resultat['valeur_mmol']."');
 	        </script>";
 	    }
 	    return $html;
@@ -1675,6 +1678,7 @@ class BiologisteController extends AbstractActionController {
 	        "<script>
 	        	$('#type_materiel_acide_urique').val('".str_replace( "'", "\'", $resultat['type_materiel'])."');
 	            $('#acide_urique').val('".$resultat['acide_urique']."');
+	            $('#acide_urique_umol').val('".$resultat['acide_urique_umol']."');
 	        </script>";
 	    }
 	    return $html;
@@ -1759,6 +1763,7 @@ class BiologisteController extends AbstractActionController {
 	        "<script>
 	         	$('#type_materiel_calcemie').val('".str_replace( "'", "\'", $resultat['type_materiel'])."');			
 	    	    $('#calcemie').val('".$resultat['calcemie']."');
+	    	    $('#calcemie_mmol').val('".$resultat['calcemie_mmol']."');
 	    	 </script>";
 	    }
 	    return $html;
@@ -1785,6 +1790,7 @@ class BiologisteController extends AbstractActionController {
 	        "<script>
   	            $('#type_materiel_phosphoremie').val('".str_replace( "'", "\'", $resultat['type_materiel'])."');			
 	    	    $('#phosphoremie').val('".$resultat['phosphoremie']."');
+	    	    $('#phosphoremie_mmol').val('".$resultat['phosphoremie_mmol']."');
 	    	 </script>";
 	    }
 	    return $html;
@@ -1975,7 +1981,7 @@ class BiologisteController extends AbstractActionController {
     	        $('#gamma').val('".$resultat['gamma']."');
     	        $('#gamma_abs').val('".$resultat['gamma_abs']."');
     	        $('#proteine_totale').val('".$resultat['proteine_totale']."');
-    	        $('#commentaire_electrophorese_proteine').val('".str_replace( "'", "\'", $resultat['commentaire'])."');
+    	        $('#commentaire_electrophorese_proteine').val('".preg_replace("/(\r\n|\n|\r)/", "\\n", str_replace( "'", "\'", $resultat['commentaire']) )."');
 	    	 </script>";
 	    }
 	    return $html;
@@ -1989,6 +1995,7 @@ class BiologisteController extends AbstractActionController {
 	        "<script>
 	            $('#type_materiel_albuminemie').val('".str_replace( "'", "\'", $resultat['type_materiel'])."');
 	    	    $('#albuminemie').val('".$resultat['albuminemie']."');
+	    	    $('#albuminemie_umol').val('".$resultat['albuminemie_umol']."');
 	    	 </script>";
 	    }
 	    return $html;
@@ -2070,6 +2077,7 @@ class BiologisteController extends AbstractActionController {
 	            $('#type_materiel_hlm_compte_daddis').val('".str_replace( "'", "\'", $resultat['type_materiel'])."');
 	    	    $('#hematies_hlm').val('".$resultat['hematies_hlm']."');
     	        $('#leucocytes_hlm').val('".$resultat['leucocytes_hlm']."');
+    	        $('#commentaire_hlm_compte_daddis').val('".$resultat['commentaire_hlm_compte_daddis']."');
 	    	 </script>";
 	    }
 	    return $html;
@@ -2157,6 +2165,7 @@ class BiologisteController extends AbstractActionController {
 	    	    $('#toxoplasmose_igm_titre').val('".$resultat['toxoplasmose_igm_titre']."');
 	    	    $('#toxoplasmose_igg').val('".$resultat['toxoplasmose_igg']."');
 	    	    $('#toxoplasmose_igg_titre').val('".$resultat['toxoplasmose_igg_titre']."');
+	    	    $('#toxoplasmose_commentaire').val('".$resultat['toxoplasmose_commentaire']."');
 	    	 </script>";
 	    }
 	    return $html;
@@ -2173,6 +2182,7 @@ class BiologisteController extends AbstractActionController {
 	    	    $('#rubeole_igm_titre').val('".$resultat['rubeole_igm_titre']."');
 	    	    $('#rubeole_igg').val('".$resultat['rubeole_igg']."');
 	    	    $('#rubeole_igg_titre').val('".$resultat['rubeole_igg_titre']."');
+	    	    $('#rubeole_commentaire').val('".$resultat['rubeole_commentaire']."');
 	    	 </script>";
 	    }
 	    return $html;
@@ -2188,13 +2198,24 @@ class BiologisteController extends AbstractActionController {
 	    		if($i > 0){
 	    			$html .= "<script> setTimeout(function(){ $('#culot_urinaire_plus').trigger('click'); }, 50); </script>";
 	    		}
-	    		$html .=
-	    		"<script>
-	              setTimeout(function(){
-	                $('#culot_urinaire_ligne_".($i+1)." .listeSelect select').val('".$resultat[$i]['culot_urinaire_1']."').trigger('onchange');
-	                $('#culot_urinaire_ligne_".($i+1)." .emplaceListeElemtsCUSelect select').val('".$resultat[$i]['culot_urinaire_2']."');
-	              }, 50);
-	    	    </script>";
+	    		
+	    		if(in_array($resultat[$i]['culot_urinaire_1'], array(1,2)) ){
+	    			$html .=
+	    			"<script>
+	                  setTimeout(function(){
+	                    $('#culot_urinaire_ligne_".($i+1)." .listeSelect select').val('".$resultat[$i]['culot_urinaire_1']."').trigger('onchange');
+	                    $('#culot_urinaire_ligne_".($i+1)." .emplaceListeElemtsCUSelect input').val('".$resultat[$i]['culot_urinaire_2']."');
+	                  }, 50);
+	    	         </script>";
+	    		}else{
+	    			$html .=
+	    			"<script>
+	                  setTimeout(function(){
+	                    $('#culot_urinaire_ligne_".($i+1)." .listeSelect select').val('".$resultat[$i]['culot_urinaire_1']."').trigger('onchange');
+	                    $('#culot_urinaire_ligne_".($i+1)." .emplaceListeElemtsCUSelect select').val('".$resultat[$i]['culot_urinaire_2']."');
+	                  }, 50);
+	    	         </script>";
+	    		}
 	    	}
 	    	$html .="<script> setTimeout(function(){ $('#conclusion_culot_urinaire_valeur').val('".str_replace( "'", "\'", $resultat[0]['conclusion'])."'); },50); </script>";
 	    
@@ -4055,7 +4076,7 @@ class BiologisteController extends AbstractActionController {
 	    $html .= "</tr>";
 	    
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
-	    $html .= "  <td colspan='2' ><label style='height: 80px;' ><span style='font-size: 16px; float: left;  margin-left: 30px;'> Commentaire:  </span> <textarea id='commentaire_hemogramme' style='max-height: 57px; min-height: 57px; max-width: 400px; min-width: 400px; margin-left: 30px;' > </textarea> </label></td>";
+	    $html .= "  <td colspan='2' ><label style='height: 80px;' ><span style='font-size: 16px; float: left;  margin-left: 30px;'> Commentaire:  </span> <textarea id='commentaire_hemogramme' style='max-height: 57px; min-height: 57px; max-width: 400px; min-width: 400px; margin-left: 30px;' readonly> </textarea> </label></td>";
 	    $html .= "  <td style='width: 30%;'><label style='padding-top: 5px; width: 80%; height: 80px; font-size: 14px;'>  </label></td>";
 	    $html .= "</tr>";
 	    
@@ -4352,7 +4373,16 @@ class BiologisteController extends AbstractActionController {
 	    $html .= "</tr>";
 	    
 	    $html .= "<script>  function getDensiteGE(valeur){ if(valeur == 'Positif'){ $('#goutte_epaisse_positif').toggle(true); }else{ $('#goutte_epaisse_positif').toggle(false); } } </script>";
-	
+	    
+	    $html .= "</table>";
+	     
+	    $html .= "<table style='width: 100%;'>";
+	     
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td colspan='2' ><label style='height: 80px;' ><span style='font-size: 16px; float: left;  margin-left: 30px;'> Commentaire:  </span> <textarea id='commentaire_goutte_epaisse' style='max-height: 57px; min-height: 57px; max-width: 400px; min-width: 400px; margin-left: 30px;' readonly> </textarea> </label></td>";
+	    $html .= "  <td style='width: 30%;'><label style='padding-top: 5px; width: 80%; height: 80px; font-size: 14px;'>  </label></td>";
+	    $html .= "</tr>";
+	    
 	    $html .= "</table> </td> </tr>";
 	
 	    return $html;
@@ -4806,6 +4836,12 @@ class BiologisteController extends AbstractActionController {
 	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'> g/l </label></td>";
 	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'> N: 0,15 &agrave; 0,45</label></td>";
 	    $html .= "</tr>";
+	    
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td style='width: 55%;'><label class='lab1' ><span style='font-weight: bold;'>  <input id='uree_sanguine_mmol' type='number' step='any' readonly> </span></label></td>";
+	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'> mmol/l </label></td>";
+	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'> ( 2,49 &agrave; 7,49 )</label></td>";
+	    $html .= "</tr>";
 	
 	    $html .= "</table> </td> </tr>";
 	
@@ -4832,9 +4868,16 @@ class BiologisteController extends AbstractActionController {
 	    
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
 	    $html .= "  <td style='width: 55%;'><label class='lab1' ><span style='font-weight: bold;'> uric&eacute;mie <input id='acide_urique' type='number' step='any' readonly> </span></label></td>";
-	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'> mg/l </label></td>";
-	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 85%;'> N : H= 35  &agrave; 72, F= 26 &agrave; 60 </label></td>";
+	    $html .= "  <td style='width: 12%;'><label class='lab2' style='padding-top: 5px;'> mg/l </label></td>";
+	    $html .= "  <td style='width: 33%;'><label class='lab3' style='padding-top: 5px; width: 85%;'> ( H= 35  &agrave; 72, F= 26 &agrave; 60 ) </label></td>";
 	    $html .= "</tr>";
+	
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td style='width: 55%;'><label class='lab1' ><span style='font-weight: bold;'> <input id='acide_urique_umol' type='number' step='any' readonly> </span></label></td>";
+	    $html .= "  <td style='width: 12%;'><label class='lab2' style='padding-top: 5px;'> umol/l </label></td>";
+	    $html .= "  <td style='width: 33%;'><label class='lab3' style='padding-top: 5px; width: 85%;'> ( H= 208  &agrave; 428, F= 154 &agrave; 356 ) </label></td>";
+	    $html .= "</tr>";
+	    
 	
 	    $html .= "</table> </td> </tr>";
 	
@@ -5153,12 +5196,22 @@ class BiologisteController extends AbstractActionController {
 	    $html .= "  <td style='width: 55%;'> <div class='noteTypeMateriel' style='float: left; height: 30px; width: 70%; padding-left: 10px;'> <input type='text' id='type_materiel_calcemie' readonly> </div> </td>";
 	    $html .= "  <td colspan='2' style='width: 45%;'> </td>";
 	    $html .= "</tr>";
+	    
+	    $html .= "</table>";
 	    //POUR LE NOM DU TYPE DE MATERIEL UTILISE
 	    
+	    $html .= "<table style='width: 100%;'>";
+	    
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
-	    $html .= "  <td style='width: 55%;'><label class='lab1' style='height: 40px;'><span style='font-weight: bold; '> calc&eacute;mie <input id='calcemie' type='number' step='any' readonly> </span></label></td>";
-	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;  height: 40px;'> mg/l </label></td>";
-	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%; height: 40px;'> N: Adultes: 86 &agrave; 103  <spa style='padding-left: 18px;'> Enfants: 100 &agrave; 120 </spa> </label></td>";
+	    $html .= "  <td style='width: 45%;'><label class='lab1' ><span style='font-weight: bold;'> Calc&eacute;mie <input id='calcemie' type='number' step='any' readonly> </span></label></td>";
+	    $html .= "  <td style='width: 10%;'><label class='lab2' style='padding-top: 5px;'> mg/l </label></td>";
+	    $html .= "  <td style='width: 45%;'><label class='lab3' style='padding-top: 5px; width: 90%;'> ( Adultes: 86 &agrave; 103 ; Enfants: 100 &agrave; 120 ) </label></td>";
+	    $html .= "</tr>";
+	    
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td style='width: 45%;'><label class='lab1' ><span style='font-weight: bold;'> Calc&eacute;mie <input id='calcemie_mmol' type='number' step='any' readonly> </span></label></td>";
+	    $html .= "  <td style='width: 10%;'><label class='lab2' style='padding-top: 5px;'> mmol/l </label></td>";
+	    $html .= "  <td style='width: 45%;'><label class='lab3' style='padding-top: 5px; width: 90%; font-size: 13px;'> ( Adultes: 2,14 &agrave; 2,56 ; Enfants: 2,49 &agrave; 2,98 ) </label></td>";
 	    $html .= "</tr>";
 	
 	    $html .= "</table> </td> </tr>";
@@ -5211,12 +5264,22 @@ class BiologisteController extends AbstractActionController {
 	    $html .= "  <td style='width: 55%;'> <div class='noteTypeMateriel' style='float: left; height: 30px; width: 70%; padding-left: 10px;'> <input type='text' id='type_materiel_phosphoremie' readonly> </div> </td>";
 	    $html .= "  <td colspan='2' style='width: 45%;'> </td>";
 	    $html .= "</tr>";
+	    
+	    $html .= "</table>";
 	    //POUR LE NOM DU TYPE DE MATERIEL UTILISE
+	     
+	    $html .= "<table style='width: 100%;'>";
 	    
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
-	    $html .= "  <td style='width: 55%;'><label class='lab1' style='height: 40px;'><span style='font-weight: bold; '> phosphor&eacute;mie <input id='phosphoremie' type='number' step='any' readonly> </span></label></td>";
-	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;  height: 40px;'> mg/l </label></td>";
-	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%; height: 40px;'> N: Adultes: 25 &agrave; 50  <spa style='padding-left: 18px;'> Enfants: 40 &agrave; 70 </spa> </label></td>";
+	    $html .= "  <td style='width: 45%;'><label class='lab1' ><span style='font-weight: bold;'> Phosphor&eacute;mie  <input id='phosphoremie' type='number' step='any' readonly> </span></label></td>";
+	    $html .= "  <td style='width: 10%;'><label class='lab2' style='padding-top: 5px;'> mg/l </label></td>";
+	    $html .= "  <td style='width: 45%;'><label class='lab3' style='padding-top: 5px; width: 90%;'> ( Adultes: 25 &agrave; 50 ;  Enfants: 40 &agrave; 70 ) </label></td>";
+	    $html .= "</tr>";
+	     
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td style='width: 45%;'><label class='lab1' ><span style='font-weight: bold;'> <input id='phosphoremie_mmol' type='number' step='any' readonly> </span></label></td>";
+	    $html .= "  <td style='width: 10%;'><label class='lab2' style='padding-top: 5px;'> mmol/l </label></td>";
+	    $html .= "  <td style='width: 45%;'><label class='lab3' style='padding-top: 5px; width: 90%;  font-size: 13px;'> ( Adultes: 8,07 &agrave; 16,15 ; Enfants: 12,92 &agrave; 22,61 ) </label></td>";
 	    $html .= "</tr>";
 	
 	    $html .= "</table> </td> </tr>";
@@ -5625,7 +5688,7 @@ class BiologisteController extends AbstractActionController {
 	    $html .= "</tr>";
 
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
-	    $html .= "  <td colspan='3' ><label style='height: 80px;' ><span style='font-size: 16px; float: left;  margin-left: 30px;'> Commentaire:  </span> <textarea id='commentaire_electrophorese_proteine' style='max-height: 57px; min-height: 57px; max-width: 400px; min-width: 400px; margin-left: 30px;' tabindex='8'> </textarea> </label></td>";
+	    $html .= "  <td colspan='3' ><label style='height: 80px;' ><span style='font-size: 16px; float: left;  margin-left: 30px;'> Commentaire:  </span> <textarea id='commentaire_electrophorese_proteine' style='max-height: 57px; min-height: 57px; max-width: 400px; min-width: 400px; margin-left: 30px;' tabindex='8' readonly> </textarea> </label></td>";
 	    $html .= "  <td style='width: 40%;'><label style='padding-top: 5px; width: 80%; height: 80px; font-size: 14px;'>  </label></td>";
 	    $html .= "</tr>";
 	    
@@ -5658,6 +5721,12 @@ class BiologisteController extends AbstractActionController {
 	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'>N : 35 - 53 </label></td>";
 	    $html .= "</tr>";
 	
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td style='width: 55%;'><label class='lab1'><span style='font-weight: bold; '>  <input id='albuminemie_umol' type='number' step='any' tabindex='2' readonly> </span></label></td>";
+	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'> umol/l </label></td>";
+	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'> ( 507,25 - 768,12 ) </label></td>";
+	    $html .= "</tr>";
+	    
 	    $html .= "</table> </td> </tr>";
 	
 	    return $html;
@@ -5720,12 +5789,14 @@ class BiologisteController extends AbstractActionController {
 	    $html .= "  <td style='width: 45%;'> <div class='noteTypeMateriel' style='float: left; height: 30px; width: 70%; padding-left: 10px;'> <input type='text' id='type_materiel_protidemie' tabindex='1' readonly> </div> </td>";
 	    $html .= "  <td colspan='3' style='width: 45%;'> </td>";
 	    $html .= "</tr>";
+	    $html .= "</table>";
 	    //POUR LE NOM DU TYPE DE MATERIEL UTILISE
 	    
+	    $html .= "<table style='width: 100%;'>";
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
-	    $html .= "  <td style='width: 45%;'><label class='lab1'><span style='font-weight: bold; '> Protid&eacute;mie <input id='protidemie' type='number' step='any' tabindex='2' readonly> </span></label></td>";
+	    $html .= "  <td style='width: 42%;'><label class='lab1'><span style='font-weight: bold; '> Protid&eacute;mie <input id='protidemie' type='number' step='any' tabindex='2' readonly> </span></label></td>";
 	    $html .= "  <td style='width: 10%;'><label class='lab2' style='padding-top: 5px;'> g/l </label></td>";
-	    $html .= "  <td style='width: 45%;'><label class='lab3' style='padding-top: 5px; width: 89%; font-size: 13px;'> N: Adultes: 66 &agrave; 83 ; Nouveaux n&eacute;s: 52 &agrave; 91 </label></td>";
+	    $html .= "  <td style='width: 48%;'><label class='lab3' style='padding-top: 5px; width: 89%; font-size: 13px;'> N: Adultes: 66 &agrave; 83 ; Nouveaux n&eacute;s: 52 &agrave; 91 </label></td>";
 	    $html .= "</tr>";
 	
 	    $html .= "</table> </td> </tr>";
@@ -5792,6 +5863,15 @@ class BiologisteController extends AbstractActionController {
 	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'> N < 2000 </label></td>";
 	    $html .= "</tr>";
 	
+	    $html .= "</table>";
+	    
+	    $html .= "<table style='width: 100%;'>";
+	    
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td colspan='2' ><label style='height: 80px;' ><span style='font-size: 16px; float: left;  margin-left: 30px;'> Commentaire:  </span> <textarea id='commentaire_hlm_compte_daddis' style='max-height: 57px; min-height: 57px; max-width: 400px; min-width: 400px; margin-left: 30px;' readonly> </textarea> </label></td>";
+	    $html .= "  <td style='width: 30%;'><label style='padding-top: 5px; width: 80%; height: 80px; font-size: 14px;'>  </label></td>";
+	    $html .= "</tr>";
+	    
 	    $html .= "</table> </td> </tr>";
 	
 	    return $html;
@@ -5816,7 +5896,7 @@ class BiologisteController extends AbstractActionController {
 	    //POUR LE NOM DU TYPE DE MATERIEL UTILISE
 	    
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
-	    $html .= "  <td style='width: 55%;'><label class='lab1'><span style='font-weight: bold; '> B&eacute;ta HCG <input id='beta_hcg_plasmatique' type='number' step='any' tabindex='2' readonly > </span></label></td>";
+	    $html .= "  <td style='width: 55%;'><label class='lab1'><span style='font-weight: bold; '> B&eacute;ta HCG <select name='beta_hcg_plasmatique' id='beta_hcg_plasmatique' disabled> <option >  </option> <option value='Positif' >Positif</option> <option value='Negatif' >N&eacute;gatif</option> </select>  </span></label></td>";
 	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'>  </label></td>";
 	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'>  </label></td>";
 	    $html .= "</tr>";
@@ -5990,6 +6070,15 @@ class BiologisteController extends AbstractActionController {
 	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'>  </label></td>";
 	    $html .= "</tr>";
 	    
+	    $html .= "</table>";
+	    
+	    $html .= "<table style='width: 100%;'>";
+	    
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td colspan='2' ><label style='height: 80px;' ><span style='font-size: 16px; float: left;  margin-left: 30px;'> Commentaire:  </span> <textarea id='toxoplasmose_commentaire' style='max-height: 57px; min-height: 57px; max-width: 400px; min-width: 400px; margin-left: 30px;' readonly> </textarea> </label></td>";
+	    $html .= "  <td style='width: 30%;'><label style='padding-top: 5px; width: 80%; height: 80px; font-size: 14px;'>  </label></td>";
+	    $html .= "</tr>";
+	    
 	    $html .= "</table> </td> </tr>";
 	   
 	    return $html;
@@ -6024,6 +6113,15 @@ class BiologisteController extends AbstractActionController {
 	    $html .= "  <td style='width: 40%;'><label class='lab1'><span style='font-weight: bold; '> IGG <select name='rubeole_igg' id='rubeole_igg' disabled> <option>  </option> <option value='Positif' >Positif</option> <option value='Negatif' >N&eacute;gatif</option> </select>  </span></label></td>";
 	    $html .= "  <td style='width: 30%;'><label class='lab2' style='padding-top: 5px;'><span style='font-weight: bold; '> Titre <input id='rubeole_igg_titre' type='number' step='any' tabindex='3' readonly> </span></label></td>";
 	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'>  </label></td>";
+	    $html .= "</tr>";
+	    
+	    $html .= "</table>";
+	    
+	    $html .= "<table style='width: 100%;'>";
+	    
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td colspan='2' ><label style='height: 80px;' ><span style='font-size: 16px; float: left;  margin-left: 30px;'> Commentaire:  </span> <textarea id='rubeole_commentaire' style='max-height: 57px; min-height: 57px; max-width: 400px; min-width: 400px; margin-left: 30px;' readonly> </textarea> </label></td>";
+	    $html .= "  <td style='width: 30%;'><label style='padding-top: 5px; width: 80%; height: 80px; font-size: 14px;'>  </label></td>";
 	    $html .= "</tr>";
 	    
 	    $html .= "</table> </td> </tr>";
@@ -6127,15 +6225,15 @@ class BiologisteController extends AbstractActionController {
 	    //POUR LE NOM DU TYPE DE MATERIEL UTILISE
 	    
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
-	    $html .= "  <td style='width: 55%;'><label class='lab1'><span style='font-weight: bold; '> RPR  <select name='serologie_syphilitique_rpr' id='serologie_syphilitique_rpr' > <option>  </option> <option value='Positif' >Positif</option> <option value='Negatif' >N&eacute;gatif</option> </select> </span></label></td>";
+	    $html .= "  <td style='width: 55%;'><label class='lab1'><span style='font-weight: bold; '> RPR  <select name='serologie_syphilitique_rpr' id='serologie_syphilitique_rpr' disabled> <option>  </option> <option value='Positif' >Positif</option> <option value='Negatif' >N&eacute;gatif</option> </select> </span></label></td>";
 	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'>  </label></td>";
 	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'>  </label></td>";
 	    $html .= "</tr>";
 	    
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
-	    $html .= "  <td style='width: 55%;'><label class='lab1'><span style='font-weight: bold; '> TPHA  <select name='serologie_syphilitique_tpha' id='serologie_syphilitique_tpha' > <option>  </option> <option value='Positif' >Positif</option> <option value='Negatif' >N&eacute;gatif</option> </select> </span></label></td>";
+	    $html .= "  <td style='width: 55%;'><label class='lab1'><span style='font-weight: bold; '> TPHA  <select name='serologie_syphilitique_tpha' id='serologie_syphilitique_tpha' disabled> <option>  </option> <option value='Positif' >Positif</option> <option value='Negatif' >N&eacute;gatif</option> </select> </span></label></td>";
 	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'> </label></td>";
-	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'> Titre <input class='serologie_syphilitique_tpha_titre' id='serologie_syphilitique_tpha_titre' type='text' style='height: 23px; margin-top: -1px; padding-left: 4px; text-align: left;' > </label></td>";
+	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'> Titre <input class='serologie_syphilitique_tpha_titre' id='serologie_syphilitique_tpha_titre' type='text' style='height: 23px; margin-top: -1px; padding-left: 4px; text-align: left;' readonly> </label></td>";
 	    $html .= "</tr>";
 	
 	    $html .= "</table> </td> </tr>";
@@ -6253,7 +6351,7 @@ class BiologisteController extends AbstractActionController {
 	    //POUR LE NOM DU TYPE DE MATERIEL UTILISE
 	    
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
-	    $html .= "  <td style='width: 55%;'><label class='lab1'><span style='font-weight: bold; '> Ag Hbs  <select name='ag_hbs' id='ag_hbs' > <option>  </option> <option value='Positif' >Positif</option> <option value='Negatif' >N&eacute;gatif</option> </select> </span></label></td>";
+	    $html .= "  <td style='width: 55%;'><label class='lab1'><span style='font-weight: bold; '> Ag Hbs  <select name='ag_hbs' id='ag_hbs' disabled> <option>  </option> <option value='Positif' >Positif</option> <option value='Negatif' >N&eacute;gatif</option> </select> </span></label></td>";
 	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'>  </label></td>";
 	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'> Qualitatif </label></td>";
 	    $html .= "</tr>";
@@ -6413,8 +6511,11 @@ class BiologisteController extends AbstractActionController {
 	    return $html;
 	}
 	
+	/**
+	 * ANCIENNE FONCTION D'IMPRESSION AVEC ZEND PDF
+	 */
 	
-	
+	/*
 	public function impressionResultatsAnalysesDemandeesAction()
 	{
 		$service = $this->layout()->user['NomService'];
@@ -6974,5 +7075,639 @@ class BiologisteController extends AbstractActionController {
 		}
 		
 	}
+	*/
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	/**
+	 * NOUVELLE FONCTION D'IMPRESSION AVEC fpdf
+	 */
+	public function impressionResultatsAnalysesDemandeesAction()
+	{
+		$nomService = $this->layout()->user['NomService'];
+		$iddemande = $this->params()->fromPost( 'iddemande' );
+		
+		$idpatient = $this->getPatientTable()->getDemandeAnalysesAvecIddemande($iddemande)['idpatient'];
+		$personne  = $this->getPersonneTable()->getPersonne($idpatient);
+		$patient   = $this->getPatientTable()->getPatient($idpatient);
+		$depistage = $this->getPatientTable()->getDepistagePatient($idpatient);
+			
+		//Recuperation de la liste des analyses pour lesquelles les résultats sont déjà renseignés et validés
+		$listeResultats = $this->getResultatDemandeAnalyseTable()->getListeResultatsAnalysesDemandeesImpSecretaire($iddemande);
+			
+	
+		$analysesDemandees = array();
+		$analysesNFS = array();
+		$analysesImmunoHemato = array();
+		$analysesCytologie = array();
+		$analysesHemostase = array();
+		$analysesMetabolismeGlucidique = array();
+		$analysesBilanLipidique = array();
+		$analysesBilanHepatique = array();
+		$analysesBilanRenal = array();
+		$analysesSerologie = array();
+		$analysesTypageHemoProteine = array();
+		$analysesTypageHemoglobine = array();
+		$analysesMetabolismeProtidique = array();
+		$analysesMetabolismeFer = array();
+		$analysesBilanElectrolyte = array();
+		
+	
+		$resultatsAnalysesDemandees = array();
+	
+		$anteriorite_nfs = array();
+		for($j = 0 , $i = 0 ; $i < count($listeResultats) ; $i++ ){
+			$idanalyse = $listeResultats[$i]['idanalyse'];
+			$iddemande = $listeResultats[$i]['iddemande'];
+	
+			//NFS  ---  NFS  ---  NFS  ---  NFS  ---  NFS  ---  NFS
+			//NFS  ---  NFS  ---  NFS  ---  NFS  ---  NFS  ---  NFS
+			if($idanalyse == 1){ //NFS
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesNFS [] = 1;
+				$resultatsAnalysesDemandees[1] = $this->getResultatDemandeAnalyseTable()->getValeursNfs($iddemande);
+					
+				//Recupération des antériorites  ----- Récupération des antériorités
+				$analysesAvecResult = $this->getResultatDemandeAnalyseTable()->getListeAnalysesNFSDemandeesAyantResultats($idpatient, $iddemande);
+					
+				if($analysesAvecResult){
+					$anteriorite_nfs['demande']  = $analysesAvecResult[0];
+					$anteriorite_nfs['resultat'] = $this->getResultatDemandeAnalyseTable()->getValeursNfs($analysesAvecResult[0]['iddemande']);
+				}
+			}
+			//=========================================================
+			//=========================================================
+				
+				
+			//IMMUNO_HEMATO  ---  IMMUNO_HEMATO  ---  IMMUNO_HEMATO
+			//IMMUNO_HEMATO  ---  IMMUNO_HEMATO  ---  IMMUNO_HEMATO
+			//IMMUNO_HEMATO  ---  IMMUNO_HEMATO  ---  IMMUNO_HEMATO
+			elseif($idanalyse == 2){ //GSRH - GROUPAGE RESHUS
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesImmunoHemato [] = 2;
+				$resultatsAnalysesDemandees[2] = $this->getResultatDemandeAnalyseTable()->getValeursGsrhGroupage($iddemande);
+			}
+				
+			elseif($idanalyse == 3){ //RECHERCHE DE L'ANTIGENE D FAIBLE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesImmunoHemato [] = 3;
+				$resultatsAnalysesDemandees[3] = $this->getResultatDemandeAnalyseTable()->getValeursRechercheAntigene($iddemande);
+			}
+				
+			elseif($idanalyse == 4){ //TEST DE COOMBS DIRECT
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesImmunoHemato [] = 4;
+				$resultatsAnalysesDemandees[4] = $this->getResultatDemandeAnalyseTable()->getValeursTestCombsDirect($iddemande);
+			}
+				
+			elseif($idanalyse == 5){ //TEST DE COOMBS INDIRECT
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesImmunoHemato [] = 5;
+				$resultatsAnalysesDemandees[5] = $this->getResultatDemandeAnalyseTable()->getValeursTestCombsIndirect($iddemande);
+			}
+				
+			elseif($idanalyse == 6){ //TEST DE COMPATIBILITE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesImmunoHemato [] = 6;
+				$resultatsAnalysesDemandees[6] = $this->getResultatDemandeAnalyseTable()->getValeursTestCompatibilite($iddemande);
+			}
+			//=========================================================
+			//=========================================================
+				
+				
+				
+			//CYTOLOGIE  ---  CYTOLOGIE  ---  CYTOLOGIE  ---  CYTOLOGIE
+			//CYTOLOGIE  ---  CYTOLOGIE  ---  CYTOLOGIE  ---  CYTOLOGIE
+			//CYTOLOGIE  ---  CYTOLOGIE  ---  CYTOLOGIE  ---  CYTOLOGIE
+			elseif($idanalyse == 7){ //VITESSE SE SEDIMENTATION (VS)
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesCytologie [] = 7;
+				$resultatsAnalysesDemandees[7] = $this->getResultatDemandeAnalyseTable()->getValeursVitesseSedimentation($iddemande);
+			}
+				
+			elseif($idanalyse == 8){ //TEST D'EMMEL (TE)
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesCytologie [] = 8;
+				$resultatsAnalysesDemandees[8] = $this->getResultatDemandeAnalyseTable()->getValeursTestDemmel($iddemande);
+			}
+				
+			elseif($idanalyse == 50){ //HLM (COMPTE D'ADDIS)
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesCytologie [] = 50;
+				$resultatsAnalysesDemandees[50] = $this->getResultatDemandeAnalyseTable()->getValeursHlmCompteDaddis($iddemande);
+			}
+				
+			elseif($idanalyse == 58){ //CULOT URINAIRE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesCytologie [] = 58;
+				$resultatsAnalysesDemandees[58] = $this->getResultatDemandeAnalyseTable()->getValeursCulotUrinaire($iddemande);
+			}
+			//=========================================================
+			//=========================================================
+				
+				
+				
+			//HEMOSTASE  ---  HEMOSTASE  ---  HEMOSTASE  --- HEMOSTASE
+			//HEMOSTASE  ---  HEMOSTASE  ---  HEMOSTASE  --- HEMOSTASE
+			//HEMOSTASE  ---  HEMOSTASE  ---  HEMOSTASE  --- HEMOSTASE
+			elseif($idanalyse == 14){ //TP - INR
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesHemostase [] = 14;
+				$resultatsAnalysesDemandees[14] = $this->getResultatDemandeAnalyseTable()->getValeursTpInr($iddemande);
+			}
+				
+			elseif($idanalyse == 15){ //TCA
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesHemostase [] = 15;
+				$resultatsAnalysesDemandees[15] = $this->getResultatDemandeAnalyseTable()->getValeursTca($iddemande);
+			}
+				
+			elseif($idanalyse == 16){ //FIBRINEMIE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesHemostase [] = 16;
+				$resultatsAnalysesDemandees[16] = $this->getResultatDemandeAnalyseTable()->getValeursFibrinemie($iddemande);
+			}
+				
+			elseif($idanalyse == 17){ //TEMPS DE SAIGNEMENT
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesHemostase [] = 17;
+				$resultatsAnalysesDemandees[17] = $this->getResultatDemandeAnalyseTable()->getValeursTempsSaignement($iddemande);
+			}
+				
+			elseif($idanalyse == 18){ //FACTEUR 8
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesHemostase [] = 18;
+				$resultatsAnalysesDemandees[18] = $this->getResultatDemandeAnalyseTable()->getValeursFacteur8($iddemande);
+			}
+				
+			elseif($idanalyse == 19){ //FACTEUR 9
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesHemostase [] = 19;
+				$resultatsAnalysesDemandees[19] = $this->getResultatDemandeAnalyseTable()->getValeursFacteur9($iddemande);
+			}
+				
+			elseif($idanalyse == 20){ //D-DIMERES
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesHemostase [] = 20;
+				$resultatsAnalysesDemandees[20] = $this->getResultatDemandeAnalyseTable()->getValeursDDimeres($iddemande);
+			}
+			//=========================================================
+			//=========================================================
+				
+				
+			//METABOLISME GLUCIDIQUE --- METABOLISME GLUCIDIQUE --- METABOLISME GLUCIDIQUE
+			//METABOLISME GLUCIDIQUE --- METABOLISME GLUCIDIQUE --- METABOLISME GLUCIDIQUE
+			//METABOLISME GLUCIDIQUE --- METABOLISME GLUCIDIQUE --- METABOLISME GLUCIDIQUE
+			elseif($idanalyse == 21){ //Glycemie
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesMetabolismeGlucidique [] = 21;
+				$resultatsAnalysesDemandees[21] = $this->getResultatDemandeAnalyseTable()->getValeursGlycemie($iddemande);
+			}
+			elseif($idanalyse == 43){ //Hemoglobine glyquee
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesMetabolismeGlucidique [] = 43;
+				$resultatsAnalysesDemandees[43] = $this->getResultatDemandeAnalyseTable()->getValeursHemoglobineGlyqueeHBAC($iddemande);
+			}
+				
+			//=========================================================
+			//=========================================================
+				
+				
+			//BILAN LIPIDIQUE --- BILAN LIPIDIQUE --- BILAN LIPIDIQUE
+			//BILAN LIPIDIQUE --- BILAN LIPIDIQUE --- BILAN LIPIDIQUE
+			//BILAN LIPIDIQUE --- BILAN LIPIDIQUE --- BILAN LIPIDIQUE
+			elseif($idanalyse == 25){ //CHOLESTEROL TOTAL
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanLipidique  [] = 25;
+				$resultatsAnalysesDemandees[25] = $this->getResultatDemandeAnalyseTable()->getValeursCholesterolTotal($iddemande);
+			}
+			elseif($idanalyse == 26){ //TRIGLYCERIDES
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanLipidique  [] = 26;
+				$resultatsAnalysesDemandees[26] = $this->getResultatDemandeAnalyseTable()->getValeursTriglycerides($iddemande);
+			}
+			elseif($idanalyse == 27){ //CHOLESTEROL HDL
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanLipidique  [] = 27;
+				$resultatsAnalysesDemandees[27] = $this->getResultatDemandeAnalyseTable()->getValeursCholesterolHDL($iddemande);
+			}
+			elseif($idanalyse == 28){ //CHOLESTEROL LDL
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanLipidique  [] = 28;
+				$resultatsAnalysesDemandees[28] = $this->getResultatDemandeAnalyseTable()->getValeursCholesterolLDL($iddemande);
+			}
+			elseif($idanalyse == 29){ //CHOLESTEROL (TOTAL - HDL - LDL) Triglyceride
+	
+				//CHOLESTEROL TOTAL
+				$analysesBilanLipidique  [] = 25;
+				$resultatsAnalysesDemandees[25] = $this->getResultatDemandeAnalyseTable()->getValeursCholesterolTotal($iddemande);
+					
+				//TRIGLYCERIDES
+				$analysesBilanLipidique  [] = 26;
+				$resultatsAnalysesDemandees[26] = $this->getResultatDemandeAnalyseTable()->getValeursTriglycerides($iddemande);
+					
+				//CHOLESTEROL HDL
+				$analysesBilanLipidique  [] = 27;
+				$resultatsAnalysesDemandees[27] = $this->getResultatDemandeAnalyseTable()->getValeursCholesterolHDL($iddemande);
+					
+				//CHOLESTEROL LDL
+				$analysesBilanLipidique  [] = 28;
+				$resultatsAnalysesDemandees[28] = $this->getResultatDemandeAnalyseTable()->getValeursCholesterolLDL($iddemande);
+					
+			}
+			elseif($idanalyse == 30){ //LIPIDES - TOTAUX
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanLipidique  [] = 30;
+				$resultatsAnalysesDemandees[30] = $this->getResultatDemandeAnalyseTable()->getValeursLipidesTotaux($iddemande);
+			}
+			//=========================================================
+			//=========================================================
+				
+				
+			//BILAN HEPATIQUE --- BILAN HEPATIQUE --- BILAN HEPATIQUE
+			//BILAN HEPATIQUE --- BILAN HEPATIQUE --- BILAN HEPATIQUE
+			//BILAN HEPATIQUE --- BILAN HEPATIQUE --- BILAN HEPATIQUE
+			elseif($idanalyse == 37){ //TRANSAMINASES (ASAT/ALAT)
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanHepatique  [] = 37;
+				$resultatsAnalysesDemandees[37][1] = $this->getResultatDemandeAnalyseTable()->getValeursTgoAsat($iddemande);
+				$resultatsAnalysesDemandees[37][2] = $this->getResultatDemandeAnalyseTable()->getValeursTgpAlat($iddemande);
+			}
+				
+			elseif($idanalyse == 38){ //PHOSPHATAGE ALCALINE (PAL)
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanHepatique  [] = 38;
+				$resultatsAnalysesDemandees[38] = $this->getResultatDemandeAnalyseTable()->getValeursPhosphatageAlcaline($iddemande);
+			}
+				
+			elseif($idanalyse == 39){ //GAMA GT = YGT
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanHepatique  [] = 39;
+				$resultatsAnalysesDemandees[39] = $this->getResultatDemandeAnalyseTable()->getValeursGamaGtYgt($iddemande);
+			}
+				
+			elseif($idanalyse == 42){ //BILIRUBINE TOTALE ET DIRECTE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanHepatique  [] = 42;
+				$resultatsAnalysesDemandees[42] = $this->getResultatDemandeAnalyseTable()->getValeursBilirubineTotaleDirecte($iddemande);
+			}
+			//=========================================================
+			//=========================================================
+				
+				
+				
+			//BILAN RENAL  ---  BILAN RENAL  ---  BILAN RENAL
+			//BILAN RENAL  ---  BILAN RENAL  ---  BILAN RENAL
+			//BILAN RENAL  ---  BILAN RENAL  ---  BILAN RENAL
+			elseif($idanalyse == 22){ //CREATININEMIE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanRenal  [] = 22;
+				$resultatsAnalysesDemandees[22] = $this->getResultatDemandeAnalyseTable()->getValeursCreatininemie($iddemande);
+			}
+				
+			elseif($idanalyse == 23){ //AZOTEMIE = UREE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanRenal  [] = 23;
+				$resultatsAnalysesDemandees[23] = $this->getResultatDemandeAnalyseTable()->getValeursAzotemie($iddemande);
+			}
+	
+			elseif($idanalyse == 46){ //ALBUMINEMIE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanRenal  [] = 46;
+				$resultatsAnalysesDemandees[46] = $this->getResultatDemandeAnalyseTable()->getValeursAlbuminemie($iddemande);
+			}
+				
+			elseif($idanalyse == 24){ //URICEMIE = ACIDE URIQUE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanRenal  [] = 24;
+				$resultatsAnalysesDemandees[24] = $this->getResultatDemandeAnalyseTable()->getValeursAcideUrique($iddemande);
+			}
+			
+			elseif($idanalyse == 47){ //ALBUMINE URINAIRE (BANDELETTES)
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanRenal [] = 47;
+				$resultatsAnalysesDemandees[47] = $this->getResultatDemandeAnalyseTable()->getValeursAlbumineUrinaire($iddemande);
+			}
+			//=========================================================
+			//=========================================================
+				
+				
+			//SEROLOGIE  ---  SEROLOGIE  ---  SEROLOGIE
+			//SEROLOGIE  ---  SEROLOGIE  ---  SEROLOGIE
+			//SEROLOGIE  ---  SEROLOGIE  ---  SEROLOGIE
+			elseif($idanalyse == 10){ //GOUTE EPAISSE / GE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesSerologie  [] = 10;
+				$resultatsAnalysesDemandees[10] = $this->getResultatDemandeAnalyseTable()->getValeursGoutteEpaisse($iddemande);
+			}
+			
+			elseif($idanalyse == 51){ //BETA HCG PLASMATIQUE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesSerologie  [] = 51;
+				$resultatsAnalysesDemandees[51] = $this->getResultatDemandeAnalyseTable()->getValeursBetaHcgPlasmatique($iddemande);
+			}
+			
+			elseif($idanalyse == 52){ //PSA
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesSerologie  [] = 52;
+				$resultatsAnalysesDemandees[52] = $this->getResultatDemandeAnalyseTable()->getValeursPsa($iddemande);
+			}
+				
+			elseif($idanalyse == 53){ //CRP ou C. Protéine Réactive 
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesSerologie  [] = 53;
+				$resultatsAnalysesDemandees[53] = $this->getResultatDemandeAnalyseTable()->getValeursCrp($iddemande);
+			}
+			
+			elseif($idanalyse == 54){ //Facteurs Rhumatoides
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesSerologie  [] = 54;
+				$resultatsAnalysesDemandees[54] = $this->getResultatDemandeAnalyseTable()->getValeursFacteursRhumatoides($iddemande);
+			}
+				
+			elseif($idanalyse == 55){ //RF Waaler Rose
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesSerologie  [] = 55;
+				$resultatsAnalysesDemandees[55] = $this->getResultatDemandeAnalyseTable()->getValeursRfWaalerRose($iddemande);
+			}
+				
+			elseif($idanalyse == 56){ //TOXOPLASMOSE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesSerologie  [] = 56;
+				$resultatsAnalysesDemandees[56] = $this->getResultatDemandeAnalyseTable()->getValeursToxoplasmose($iddemande);
+			}
+				
+			elseif($idanalyse == 57){ //RUBEOLE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesSerologie  [] = 57;
+				$resultatsAnalysesDemandees[57] = $this->getResultatDemandeAnalyseTable()->getValeursRubeole($iddemande);
+			}
+				
+			elseif($idanalyse == 60){ //Serologie Syphilitique
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesSerologie  [] = 60;
+				$resultatsAnalysesDemandees[60] = $this->getResultatDemandeAnalyseTable()->getValeursSerologieSyphilitique($iddemande);
+			}
+				
+			elseif($idanalyse == 61){ //ASLO
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesSerologie  [] = 61;
+				$resultatsAnalysesDemandees[61] = $this->getResultatDemandeAnalyseTable()->getValeursAslo($iddemande);
+			}
+				
+			elseif($idanalyse == 62){ //WIDAL
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesSerologie  [] = 62;
+				$resultatsAnalysesDemandees[62] = $this->getResultatDemandeAnalyseTable()->getValeursWidal($iddemande);
+			}
+				
+			elseif($idanalyse == 63){ //Ag HBS
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesSerologie  [] = 63;
+				$resultatsAnalysesDemandees[63] = $this->getResultatDemandeAnalyseTable()->getValeursAgHbs($iddemande);
+			}
+			
+			
+			
+			//=========================================================
+			//=========================================================
+				
+				
+			//TYPAGE DE L'HEMOGLOBINE (Avec ELECTROPHORESE DE L'HEMOGLOBINE et DES PROTEINES)
+			//TYPAGE DE L'HEMOGLOBINE (Avec ELECTROPHORESE DE L'HEMOGLOBINE et DES PROTEINES)
+			//TYPAGE DE L'HEMOGLOBINE (Avec ELECTROPHORESE DE L'HEMOGLOBINE et DES PROTEINES)
+			elseif($idanalyse == 44){ //ELECTROPHORESE DE HEMOGLOBINE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesTypageHemoProteine[44] = 44;
+				$resultatsAnalysesDemandees[44] = $this->getResultatDemandeAnalyseTable()->getValeursElectrophoreseHemoglobine($iddemande);
+			}
+	
+			//=========================================================
+			//=========================================================
+				
+	
+			//METABOLISME PROTIDIQUE  ---  METABOLISME PROTIDIQUE
+			//METABOLISME PROTIDIQUE  ---  METABOLISME PROTIDIQUE
+			//METABOLISME PROTIDIQUE  ---  METABOLISME PROTIDIQUE
+			elseif($idanalyse == 45){ //ELECTROPHORESE DES PROTEINES
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesMetabolismeProtidique[45] = 45;
+				$resultatsAnalysesDemandees[45] = $this->getResultatDemandeAnalyseTable()->getValeursElectrophoreseProteines($iddemande);
+			}
+	
+			elseif($idanalyse == 48){ //PROTEINES TOTAL (PROTIDEMIE)
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesMetabolismeProtidique[48] = 48;
+				$resultatsAnalysesDemandees[48] = $this->getResultatDemandeAnalyseTable()->getValeursProtidemie($iddemande);
+			}
+	
+			elseif($idanalyse == 49){ //PROTEINURIE DES 24H (PU 24H)
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesMetabolismeProtidique [49] = 49;
+				$resultatsAnalysesDemandees[49] = $this->getResultatDemandeAnalyseTable()->getValeursProteinurie($iddemande);
+			}
+			//=========================================================
+			//=========================================================
+				
+				
+			//METABOLISME DU FER --- METABOLISME DU FER
+			//METABOLISME DU FER --- METABOLISME DU FER
+			//METABOLISME DU FER --- METABOLISME DU FER
+			elseif($idanalyse == 40){ //FER SERIQUE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesMetabolismeFer[40] = 40;
+				$resultatsAnalysesDemandees[40] = $this->getResultatDemandeAnalyseTable()->getValeursFerSerique($iddemande);
+			}
+			elseif($idanalyse == 41){ //FERRITININE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesMetabolismeFer[41] = 41;
+				$resultatsAnalysesDemandees[41] = $this->getResultatDemandeAnalyseTable()->getValeursFerritinine($iddemande);
+			}
+			//=========================================================
+			//=========================================================
+				
+			
+			//BILAN D'ELECTROLYTE --- BILAN D'ELECTROLYTE
+			//BILAN D'ELECTROLYTE --- BILAN D'ELECTROLYTE
+			//BILAN D'ELECTROLYTE --- BILAN D'ELECTROLYTE
+			elseif($idanalyse == 31){ //IONOGRAMME
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanElectrolyte[31] = 31;
+				$resultatsAnalysesDemandees[31] = $this->getResultatDemandeAnalyseTable()->getValeursIonogramme($iddemande);
+			}
+			elseif($idanalyse == 32){ //CALCEMIE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanElectrolyte[32] = 32;
+				$resultatsAnalysesDemandees[32] = $this->getResultatDemandeAnalyseTable()->getValeursCalcemie($iddemande);
+			}
+			elseif($idanalyse == 33){ //MAGNESEMIE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanElectrolyte[33] = 33;
+				$resultatsAnalysesDemandees[33] = $this->getResultatDemandeAnalyseTable()->getValeursMagnesemie($iddemande);
+			}
+			elseif($idanalyse == 34){ //PHOSPHOREMIE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesBilanElectrolyte[34] = 34;
+				$resultatsAnalysesDemandees[34] = $this->getResultatDemandeAnalyseTable()->getValeursPhosphoremie($iddemande);
+			}
+			//=========================================================
+			//=========================================================
+			
+			
+				
+			//TYPAGE DE L'HEMOGLOBINE  ---  TYPAGE DE L'HEMOGLOBINE
+			//TYPAGE DE L'HEMOGLOBINE  ---  TYPAGE DE L'HEMOGLOBINE
+			//TYPAGE DE L'HEMOGLOBINE  ---  TYPAGE DE L'HEMOGLOBINE
+			elseif($idanalyse == 68){ //TYPAGE DE L'HEMOGLOBINE
+				$analysesDemandees  [$j++] = $listeResultats[$i];
+				$analysesTypageHemoglobine [] = 68;
+				$resultatsAnalysesDemandees[68] = $this->getResultatDemandeAnalyseTable()->getValeursTypageHemoglobineLibelle($iddemande);
+			}
+			//=========================================================
+			//=========================================================
+				
+		}
+	
+		//******************************************************
+		//******************************************************
+		//************** Création de l'imprimé pdf *************
+		//******************************************************
+		//******************************************************
+		//Créer le document
+		$pdf = new ImprimerResultatsAnalysesDemandees();
+		$pdf->SetMargins(12.5,11.5,12.5);
+		
+		//Ajout d'informations sur le service et le patient
+		$pdf->setNomService($nomService);
+		$pdf->setInfosPatients($personne);
+		$pdf->setPatient($patient);
+		$pdf->setDepistage($depistage);
+		
+		//Liste de toutes les informations sur les analyses à imprimer
+		$pdf->setAnalysesDemandees($analysesDemandees);
+		
+		//Liste des analyses à imprimer
+		$pdf->setResultatsAnalysesDemandees($resultatsAnalysesDemandees);
+		
+		//========= Créaton de la page 1 ========
+		//========= Créaton de la page 1 ========
+		//========= Créaton de la page 1 ========
+		if($analysesNFS){
+			$pdf->setAnterioriteNfs($anteriorite_nfs);
+			
+			/*
+			 * Envoie des données pour affichage
+			*/
+			$pdf->affichageResultatAnalyseNFS();
+		}
+	
+		//========= Créaton des autres pages ========
+		//========= Créaton des autres pages ========
+		//========= Créaton des autres pages ========
+		if($analysesImmunoHemato || $analysesCytologie || $analysesHemostase || $analysesMetabolismeGlucidique ||
+		$analysesBilanLipidique || $analysesBilanHepatique || $analysesBilanRenal || $analysesSerologie || $analysesTypageHemoProteine ||
+		$analysesMetabolismeFer || $analysesMetabolismeProtidique){
+		    
+			//GESTION DES ANALYSES DE L'IMMUNO_HEMATO
+			$pdf->setAnalysesImmunoHemato($analysesImmunoHemato);
+		
+		    //GESTION DES ANALYSES DE LA CYTOLOGIE
+		    $pdf->setAnalysesCytologie($analysesCytologie);
+		    
+		    //GESTION DES ANALYSES DE L'HEMOSTASE 
+		    $pdf->setAnalysesHemostase($analysesHemostase);
+		    
+		    //GESTION DES ANALYSES DE SEROLOGIE
+		    $pdf->setAnalysesSerologie($analysesSerologie);
+		    
+		    //GESTION DES ANALYSES DU BILAN HEPATIQUE
+		    $pdf->setAnalysesBilanHepatique($analysesBilanHepatique);
+		    
+		    //GESTION DES ANALYSES DU BILAN RENAL
+		    $pdf->setAnalysesBilanRenal($analysesBilanRenal);
+		    
+		    //GESTION DES ANALYSES DU METABOLISME GLUCIDIQUE
+		    $pdf->setAnalysesMetabolismeGlucidique($analysesMetabolismeGlucidique);
+		    
+		    //GESTION DES ANALYSES DU BILAN LIPIDIQUE
+		    $pdf->setAnalysesBilanLipidique($analysesBilanLipidique);
+		    
+		    //GESTION DES ANALYSES DE METABOLISME DU FER
+		    $pdf->setAnalysesMetabolismeFer($analysesMetabolismeFer);
+		    
+		    //GESTION DES ANALYSES DU BILAN D'ELECTROLYTE
+		    $pdf->setAnalysesBilanElectrolyte($analysesBilanElectrolyte);
+		    
+		    //GESTION DES ANALYSES DU TYPAGE (Helectrophorèse)
+		    $pdf->setAnalysesTypageHemoProteine($analysesTypageHemoProteine);
+		    
+		    //GESTION DES ANALYSES DE METABOLISME PROTIDIQUE
+		    $pdf->setAnalysesMetabolismeProtidique($analysesMetabolismeProtidique);
+		    
+		    
+		    /*
+		     * Envoie des données pour affichage
+		    */
+		    $pdf->affichageResultatsAnalysesDemandees();
+		}
+		
+		
+		//========= Créaton de la dernière page ========
+		//========= Créaton de la dernière page ========
+		//========= Créaton de la dernière page ========
+		if($analysesTypageHemoglobine){
+				
+			$pdf->setAnalysesTypageHemoglobine($analysesTypageHemoglobine);
+			
+			/*
+			 * Envoie des données pour affichage
+			 */
+			$pdf->affichageResultatsTypageHemoglobine();
+		}
+	
+		
+		//Afficher le document contenant les différentes pages
+		//Afficher le document contenant les différentes pages
+		//Afficher le document contenant les différentes pages
+		$pdf->Output('I');
+			
+		
+		
+	
+	}
+	
+	
 	
 }

--- a/module/Laboratoire/src/Laboratoire/Controller/TechnicienController.php
+++ b/module/Laboratoire/src/Laboratoire/Controller/TechnicienController.php
@@ -3264,6 +3264,7 @@ class TechnicienController extends AbstractActionController {
  	        	$('.ER_".$iddemande." #type_materiel_goutte_epaisse').val('".str_replace( "'", "\'",$resultat['type_materiel'])."');
 	            $('.ER_".$iddemande." #goutte_epaisse').val('".$resultat['goutte_epaisse']."');
 	            if('".$resultat['goutte_epaisse']."' == 'Positif'){ $('.ER_".$iddemande." #goutte_epaisse_positif').toggle(true); $('.ER_".$iddemande." #densite_parasitaire').val('".$resultat['densite_parasitaire']."'); }
+	            $('.ER_".$iddemande." #commentaire_goutte_epaisse').val('".str_replace( "'", "\'",$resultat['commentaire_goutte_epaisse'])."');		
 	        </script>";
 	    }
 	    return $html;
@@ -3401,6 +3402,7 @@ class TechnicienController extends AbstractActionController {
 	        "<script>
 	        	$('#type_materiel_azotemie').val('".str_replace( "'", "\'", $resultat['type_materiel'])."');	
 	            $('#uree_sanguine').val('".$resultat['valeur']."');
+	            $('#uree_sanguine_mmol').val('".$resultat['valeur_mmol']."');
 	        </script>";
 	    }
 	    return $html;
@@ -3414,6 +3416,7 @@ class TechnicienController extends AbstractActionController {
 	        "<script>
         		$('#type_materiel_acide_urique').val('".str_replace( "'", "\'", $resultat['type_materiel'])."');
 	            $('#acide_urique').val('".$resultat['acide_urique']."');
+	            $('#acide_urique_umol').val('".$resultat['acide_urique_umol']."');
 	        </script>";
 	    }
 	    return $html;
@@ -3498,6 +3501,7 @@ class TechnicienController extends AbstractActionController {
 	        "<script>
    	            $('#type_materiel_calcemie').val('".str_replace( "'", "\'", $resultat['type_materiel'])."');			
 	    	    $('#calcemie').val('".$resultat['calcemie']."');
+	    	    $('#calcemie_mmol').val('".$resultat['calcemie_mmol']."');
 	    	 </script>";
 	    }
 	    return $html;
@@ -3524,6 +3528,7 @@ class TechnicienController extends AbstractActionController {
 	        "<script>
    	            $('#type_materiel_phosphoremie').val('".str_replace( "'", "\'", $resultat['type_materiel'])."');			
 	    	    $('#phosphoremie').val('".$resultat['phosphoremie']."');
+	    	    $('#phosphoremie_mmol').val('".$resultat['phosphoremie_mmol']."');
 	    	 </script>";
 	    }
 	    return $html;
@@ -3725,6 +3730,7 @@ class TechnicienController extends AbstractActionController {
 	        "<script>
 	            $('#type_materiel_albuminemie').val('".str_replace( "'", "\'", $resultat['type_materiel'])."');
 	    	    $('#albuminemie').val('".$resultat['albuminemie']."');
+	    	    $('#albuminemie_umol').val('".$resultat['albuminemie_umol']."');
 	    	 </script>";
 	    }
 	    return $html;
@@ -3810,6 +3816,7 @@ class TechnicienController extends AbstractActionController {
 	            $('#type_materiel_hlm_compte_daddis').val('".str_replace( "'", "\'", $resultat['type_materiel'])."');
 	    	    $('#hematies_hlm').val('".$resultat['hematies_hlm']."');
     	        $('#leucocytes_hlm').val('".$resultat['leucocytes_hlm']."');
+    	        $('#commentaire_hlm_compte_daddis').val('".$resultat['commentaire_hlm_compte_daddis']."');
 	    	 </script>";
 	    }
 	    return $html;
@@ -3896,6 +3903,7 @@ class TechnicienController extends AbstractActionController {
 	    	    $('#toxoplasmose_igm_titre').val('".$resultat['toxoplasmose_igm_titre']."');
 	    	    $('#toxoplasmose_igg').val('".$resultat['toxoplasmose_igg']."');
 	    	    $('#toxoplasmose_igg_titre').val('".$resultat['toxoplasmose_igg_titre']."');
+	    	    $('#toxoplasmose_commentaire').val('".$resultat['toxoplasmose_commentaire']."');
 	    	 </script>";
 	    }
 	    return $html;
@@ -3912,6 +3920,7 @@ class TechnicienController extends AbstractActionController {
 	    	    $('#rubeole_igm_titre').val('".$resultat['rubeole_igm_titre']."');
 	    	    $('#rubeole_igg').val('".$resultat['rubeole_igg']."');
 	    	    $('#rubeole_igg_titre').val('".$resultat['rubeole_igg_titre']."');
+	    	    $('#rubeole_commentaire').val('".$resultat['rubeole_commentaire']."');
 	    	 </script>";
 	    }
 	    return $html;
@@ -3927,13 +3936,25 @@ class TechnicienController extends AbstractActionController {
 	    		if($i > 0){
 	    			$html .= "<script> setTimeout(function(){ $('#culot_urinaire_plus').trigger('click'); }, 50); </script>";
 	    		}
-	    		$html .=
-	    		"<script>
-	              setTimeout(function(){
-	                $('#culot_urinaire_ligne_".($i+1)." .listeSelect select').val('".$resultat[$i]['culot_urinaire_1']."').trigger('onchange');
-	                $('#culot_urinaire_ligne_".($i+1)." .emplaceListeElemtsCUSelect select').val('".$resultat[$i]['culot_urinaire_2']."');
-	              }, 50);
-	    	    </script>";
+	    		
+	    		if(in_array($resultat[$i]['culot_urinaire_1'], array(1,2)) ){
+	    			$html .=
+	    			"<script>
+	                  setTimeout(function(){
+	                    $('#culot_urinaire_ligne_".($i+1)." .listeSelect select').val('".$resultat[$i]['culot_urinaire_1']."').trigger('onchange');
+	                    $('#culot_urinaire_ligne_".($i+1)." .emplaceListeElemtsCUSelect input').val('".$resultat[$i]['culot_urinaire_2']."');
+	                  }, 50);
+	    	         </script>";
+	    		}else{
+	    			$html .=
+	    			"<script>
+	                  setTimeout(function(){
+	                    $('#culot_urinaire_ligne_".($i+1)." .listeSelect select').val('".$resultat[$i]['culot_urinaire_1']."').trigger('onchange');
+	                    $('#culot_urinaire_ligne_".($i+1)." .emplaceListeElemtsCUSelect select').val('".$resultat[$i]['culot_urinaire_2']."');
+	                  }, 50);
+	    	         </script>";
+	    		}
+	    		
 	    	}
 	    	$html .="<script> setTimeout(function(){ $('#conclusion_culot_urinaire_valeur').val('".str_replace( "'", "\'", $resultat[0]['conclusion'])."'); },50); </script>";
 	    
@@ -6142,6 +6163,14 @@ class TechnicienController extends AbstractActionController {
 	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'>  </label></td>";
 	    $html .= "</tr>";
 	    
+	    $html .= "</table>";
+	    
+	    $html .= "<table style='width: 100%;'>";
+	    
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td colspan='2' ><label style='height: 80px;' ><span style='font-size: 16px; float: left;  margin-left: 30px;'> Commentaire:  </span> <textarea id='commentaire_goutte_epaisse' style='max-height: 57px; min-height: 57px; max-width: 400px; min-width: 400px; margin-left: 30px;' > </textarea> </label></td>";
+	    $html .= "  <td style='width: 30%;'><label style='padding-top: 5px; width: 80%; height: 80px; font-size: 14px;'>  </label></td>";
+	    $html .= "</tr>";
 	    	
 	    $html .= "</table> </td> </tr>";
 	
@@ -6596,6 +6625,12 @@ class TechnicienController extends AbstractActionController {
 	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'> g/l </label></td>";
 	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'> N: 0,15 &agrave; 0,45</label></td>";
 	    $html .= "</tr>";
+	    
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td style='width: 55%;'><label class='lab1' ><span style='font-weight: bold;'>  <input id='uree_sanguine_mmol' type='number' step='any' readonly> </span></label></td>";
+	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'> mmol/l </label></td>";
+	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'> ( 2,49 &agrave; 7,49 )</label></td>";
+	    $html .= "</tr>";
 	
 	    $html .= "</table> </td> </tr>";
 	
@@ -6622,10 +6657,16 @@ class TechnicienController extends AbstractActionController {
 	    
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
 	    $html .= "  <td style='width: 55%;'><label class='lab1' ><span style='font-weight: bold;'> uric&eacute;mie <input id='acide_urique' type='number' step='any'> </span></label></td>";
-	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'> mg/l </label></td>";
-	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 85%;'> N : H= 35  &agrave; 72, F= 26 &agrave; 60 </label></td>";
+	    $html .= "  <td style='width: 12%;'><label class='lab2' style='padding-top: 5px;'> mg/l </label></td>";
+	    $html .= "  <td style='width: 33%;'><label class='lab3' style='padding-top: 5px; width: 85%;'> ( H= 35  &agrave; 72, F= 26 &agrave; 60 ) </label></td>";
 	    $html .= "</tr>";
 	
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td style='width: 55%;'><label class='lab1' ><span style='font-weight: bold;'> <input id='acide_urique_umol' type='number' step='any' readonly> </span></label></td>";
+	    $html .= "  <td style='width: 12%;'><label class='lab2' style='padding-top: 5px;'> umol/l </label></td>";
+	    $html .= "  <td style='width: 33%;'><label class='lab3' style='padding-top: 5px; width: 85%;'> ( H= 208  &agrave; 428, F= 154 &agrave; 356 ) </label></td>";
+	    $html .= "</tr>";
+	    
 	    $html .= "</table> </td> </tr>";
 	
 	    return $html;
@@ -6939,14 +6980,24 @@ class TechnicienController extends AbstractActionController {
 	    $html .= "  <td style='width: 55%;'> <div class='noteTypeMateriel' style='float: left; height: 30px; width: 70%; padding-left: 10px;'> <input type='text' id='type_materiel_calcemie' > </div> </td>";
 	    $html .= "  <td colspan='2' style='width: 45%;'> </td>";
 	    $html .= "</tr>";
+	    
+	    $html .= "</table>";
 	    //POUR LE NOM DU TYPE DE MATERIEL UTILISE
 	    
+	    $html .= "<table style='width: 100%;'>";
+	    
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
-	    $html .= "  <td style='width: 55%;'><label class='lab1' style='height: 40px;'><span style='font-weight: bold; '> calc&eacute;mie <input id='calcemie' type='number' step='any'> </span></label></td>";
-	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;  height: 40px;'> mg/l </label></td>";
-	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%; height: 40px;'> N: Adultes: 86 &agrave; 103  <spa style='padding-left: 18px;'> Enfants: 100 &agrave; 120 </spa> </label></td>";
+	    $html .= "  <td style='width: 45%;'><label class='lab1' ><span style='font-weight: bold;'> Calc&eacute;mie <input id='calcemie' type='number' step='any'> </span></label></td>";
+	    $html .= "  <td style='width: 10%;'><label class='lab2' style='padding-top: 5px;'> mg/l </label></td>";
+	    $html .= "  <td style='width: 45%;'><label class='lab3' style='padding-top: 5px; width: 90%;'> ( Adultes: 86 &agrave; 103 ; Enfants: 100 &agrave; 120 ) </label></td>";
 	    $html .= "</tr>";
-	
+	    
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td style='width: 45%;'><label class='lab1' ><span style='font-weight: bold;'> Calc&eacute;mie <input id='calcemie_mmol' type='number' step='any' readonly> </span></label></td>";
+	    $html .= "  <td style='width: 10%;'><label class='lab2' style='padding-top: 5px;'> mmol/l </label></td>";
+	    $html .= "  <td style='width: 45%;'><label class='lab3' style='padding-top: 5px; width: 90%; font-size: 13px;'> ( Adultes: 2,14 &agrave; 2,56 ; Enfants: 2,49 &agrave; 2,98 ) </label></td>";
+	    $html .= "</tr>";
+	    
 	    $html .= "</table> </td> </tr>";
 	
 	    return $html;
@@ -6997,14 +7048,25 @@ class TechnicienController extends AbstractActionController {
 	    $html .= "  <td style='width: 55%;'> <div class='noteTypeMateriel' style='float: left; height: 30px; width: 70%; padding-left: 10px;'> <input type='text' id='type_materiel_phosphoremie' > </div> </td>";
 	    $html .= "  <td colspan='2' style='width: 45%;'> </td>";
 	    $html .= "</tr>";
+	    
+	    $html .= "</table>";
 	    //POUR LE NOM DU TYPE DE MATERIEL UTILISE
 	    
+	    $html .= "<table style='width: 100%;'>";
+	    
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
-	    $html .= "  <td style='width: 55%;'><label class='lab1' style='height: 40px;'><span style='font-weight: bold; '> phosphor&eacute;mie <input id='phosphoremie' type='number' step='any'> </span></label></td>";
-	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;  height: 40px;'> mg/l </label></td>";
-	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%; height: 40px;'> N: Adultes: 25 &agrave; 50  <spa style='padding-left: 18px;'> Enfants: 40 &agrave; 70 </spa> </label></td>";
+	    $html .= "  <td style='width: 45%;'><label class='lab1' ><span style='font-weight: bold;'> Phosphor&eacute;mie  <input id='phosphoremie' type='number' step='any'> </span></label></td>";
+	    $html .= "  <td style='width: 10%;'><label class='lab2' style='padding-top: 5px;'> mg/l </label></td>";
+	    $html .= "  <td style='width: 45%;'><label class='lab3' style='padding-top: 5px; width: 90%;'> ( Adultes: 25 &agrave; 50 ;  Enfants: 40 &agrave; 70 ) </label></td>";
 	    $html .= "</tr>";
-	
+	     
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td style='width: 45%;'><label class='lab1' ><span style='font-weight: bold;'> <input id='phosphoremie_mmol' type='number' step='any' readonly> </span></label></td>";
+	    $html .= "  <td style='width: 10%;'><label class='lab2' style='padding-top: 5px;'> mmol/l </label></td>";
+	    $html .= "  <td style='width: 45%;'><label class='lab3' style='padding-top: 5px; width: 90%;  font-size: 13px;'> ( Adultes: 8,07 &agrave; 16,15 ; Enfants: 12,92 &agrave; 22,61 ) </label></td>";
+	    $html .= "</tr>";
+	    
+	    
 	    $html .= "</table> </td> </tr>";
 	
 	    return $html;
@@ -7442,7 +7504,13 @@ class TechnicienController extends AbstractActionController {
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
 	    $html .= "  <td style='width: 55%;'><label class='lab1'><span style='font-weight: bold; '> Albumin&eacute;mie <input id='albuminemie' type='number' step='any' tabindex='2'> </span></label></td>";
 	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'> g/l </label></td>";
-	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'>N : 35 - 53 </label></td>";
+	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'>( 35 - 53 )</label></td>";
+	    $html .= "</tr>";
+	    
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td style='width: 55%;'><label class='lab1'><span style='font-weight: bold; '>  <input id='albuminemie_umol' type='number' step='any' tabindex='2' readonly> </span></label></td>";
+	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'> umol/l </label></td>";
+	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'> ( 507,25 - 768,12 ) </label></td>";
 	    $html .= "</tr>";
 	
 	    $html .= "</table> </td> </tr>";
@@ -7578,7 +7646,16 @@ class TechnicienController extends AbstractActionController {
 	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'> /min </label></td>";
 	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'> N < 2000 </label></td>";
 	    $html .= "</tr>";
+	    
+	    $html .= "</table>";
 	
+	    $html .= "<table style='width: 100%;'>";
+	     
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td colspan='2' ><label style='height: 80px;' ><span style='font-size: 16px; float: left;  margin-left: 30px;'> Commentaire:  </span> <textarea id='commentaire_hlm_compte_daddis' style='max-height: 57px; min-height: 57px; max-width: 400px; min-width: 400px; margin-left: 30px;' > </textarea> </label></td>";
+	    $html .= "  <td style='width: 30%;'><label style='padding-top: 5px; width: 80%; height: 80px; font-size: 14px;'>  </label></td>";
+	    $html .= "</tr>";
+	    
 	    $html .= "</table> </td> </tr>";
 	
 	    return $html;
@@ -7603,7 +7680,7 @@ class TechnicienController extends AbstractActionController {
 	    //POUR LE NOM DU TYPE DE MATERIEL UTILISE
 	    
 	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
-	    $html .= "  <td style='width: 55%;'><label class='lab1'><span style='font-weight: bold; '> B&eacute;ta HCG <input id='beta_hcg_plasmatique' type='number' step='any' tabindex='2'> </span></label></td>";
+	    $html .= "  <td style='width: 55%;'><label class='lab1'><span style='font-weight: bold; '> B&eacute;ta HCG <select name='beta_hcg_plasmatique' id='beta_hcg_plasmatique' > <option >  </option> <option value='Positif' >Positif</option> <option value='Negatif' >N&eacute;gatif</option> </select> </span></label></td>";
 	    $html .= "  <td style='width: 15%;'><label class='lab2' style='padding-top: 5px;'>  </label></td>";
 	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'>  </label></td>";
 	    $html .= "</tr>";
@@ -7778,6 +7855,15 @@ class TechnicienController extends AbstractActionController {
 	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'>  </label></td>";
 	    $html .= "</tr>";
 	
+	    $html .= "</table>";
+	     
+	    $html .= "<table style='width: 100%;'>";
+	     
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td colspan='2' ><label style='height: 80px;' ><span style='font-size: 16px; float: left;  margin-left: 30px;'> Commentaire:  </span> <textarea id='toxoplasmose_commentaire' style='max-height: 57px; min-height: 57px; max-width: 400px; min-width: 400px; margin-left: 30px;' > </textarea> </label></td>";
+	    $html .= "  <td style='width: 30%;'><label style='padding-top: 5px; width: 80%; height: 80px; font-size: 14px;'>  </label></td>";
+	    $html .= "</tr>";
+	    
 	    $html .= "</table> </td> </tr>";
 	
 	    return $html;
@@ -7812,6 +7898,15 @@ class TechnicienController extends AbstractActionController {
 	    $html .= "  <td style='width: 40%;'><label class='lab1'><span style='font-weight: bold; '> IgG <select name='rubeole_igg' id='rubeole_igg' > <option>  </option> <option value='Positif' >Positif</option> <option value='Negatif' >N&eacute;gatif</option> </select>  </span></label></td>";
 	    $html .= "  <td style='width: 30%;'><label class='lab2' style='padding-top: 5px;'><span style='font-weight: bold; '> Titre <input id='rubeole_igg_titre' type='number' step='any' tabindex='3'> </span></label></td>";
 	    $html .= "  <td style='width: 30%;'><label class='lab3' style='padding-top: 5px; width: 80%;'>  </label></td>";
+	    $html .= "</tr>";
+	    
+	    $html .= "</table>";
+	     
+	    $html .= "<table style='width: 100%;'>";
+	     
+	    $html .= "<tr class='ligneAnanlyse' style='width: 100%;'>";
+	    $html .= "  <td colspan='2' ><label style='height: 80px;' ><span style='font-size: 16px; float: left;  margin-left: 30px;'> Commentaire:  </span> <textarea id='rubeole_commentaire' style='max-height: 57px; min-height: 57px; max-width: 400px; min-width: 400px; margin-left: 30px;' > </textarea> </label></td>";
+	    $html .= "  <td style='width: 30%;'><label style='padding-top: 5px; width: 80%; height: 80px; font-size: 14px;'>  </label></td>";
 	    $html .= "</tr>";
 	    
 	    $html .= "</table> </td> </tr>";

--- a/module/Laboratoire/src/Laboratoire/Model/ResultatDemandeAnalyseTable.php
+++ b/module/Laboratoire/src/Laboratoire/Model/ResultatDemandeAnalyseTable.php
@@ -621,7 +621,9 @@ class ResultatDemandeAnalyseTable {
 	    $donnees = array();
 	    $donnees['goutte_epaisse'] = $tab[1];
 	    if($tab[2]){ $donnees['densite_parasitaire'] = $tab[2]; } else { $donnees['densite_parasitaire'] = null; }
-	     
+	    if($tab[4]){ $donnees['commentaire_goutte_epaisse'] = $tab[4]; }else{ $donnees['commentaire_goutte_epaisse'] = null; } 
+	    
+	    
 	    if( $donnees['goutte_epaisse'] ){ $donneesExiste = 1; $donnees['type_materiel'] = $tab[3]; }
 	
 	    //Si les resultats n y sont pas on les ajoute
@@ -1188,6 +1190,7 @@ class ResultatDemandeAnalyseTable {
 	    $donnees = array();
 	    $donnees['valeur'] = $tab[1];
 	    $donnees['type_materiel'] = $tab[2];
+	    $donnees['valeur_mmol'] = $tab[3];
 	
 	    if($donnees['valeur']){ $donneesExiste = 1; }
 	
@@ -1243,6 +1246,7 @@ class ResultatDemandeAnalyseTable {
 	
 	    $donnees = array();
 	    $donnees['acide_urique'] = $tab[1];
+	    $donnees['acide_urique_umol'] = $tab[3];
 	
 	    if($donnees['acide_urique']){ $donneesExiste = 1;  $donnees['type_materiel'] = $tab[2];}
 	
@@ -1775,8 +1779,13 @@ class ResultatDemandeAnalyseTable {
 	     
 	    $donnees = array();
 	    $donnees['calcemie'] = $tab[1];
+	    
 	
-	    if($donnees['calcemie']){ $donneesExiste = 1; $donnees['type_materiel'] = $tab[2];}
+	    if($donnees['calcemie']){ 
+	    	$donneesExiste = 1; 
+	    	$donnees['type_materiel'] = $tab[2];
+	    	$donnees['calcemie_mmol'] = $tab[3];
+	    }
 	     
 	    //Si les resultats n y sont pas on les ajoute
 	    if(!$this->getValeursCalcemie($iddemande)){
@@ -1885,7 +1894,11 @@ class ResultatDemandeAnalyseTable {
 	    $donnees = array();
 	    $donnees['phosphoremie'] = $tab[1];
 	
-	    if($donnees['phosphoremie']){ $donneesExiste = 1; $donnees['type_materiel'] = $tab[2];}
+	    if($donnees['phosphoremie']){ 
+	    	$donneesExiste = 1; 
+	    	$donnees['type_materiel'] = $tab[2];
+	    	$donnees['phosphoremie_mmol'] = $tab[3];
+	    }
 	
 	    //Si les resultats n y sont pas on les ajoute
 	    if(!$this->getValeursPhosphoremie($iddemande)){
@@ -2720,6 +2733,7 @@ class ResultatDemandeAnalyseTable {
 	
 	    if($tab[1]){ $donnees['type_materiel'] = $tab[1]; }else{ $donnees['type_materiel'] = null; }
 	    if($tab[2]){ $donnees['albuminemie']   = $tab[2]; }else{ $donnees['albuminemie']   = null; }
+	    if($tab[3]){ $donnees['albuminemie_umol'] = $tab[3]; }else{ $donnees['albuminemie_umol'] = null; }
 	
 	    if($tab[2]){ $donneesExiste = 1; }
 	
@@ -2987,6 +3001,7 @@ class ResultatDemandeAnalyseTable {
 	    if($tab[1]){ $donnees['type_materiel'] = $tab[1]; }else{ $donnees['type_materiel'] = null; }
 	    if($tab[2]){ $donnees['hematies_hlm']  = $tab[2]; }else{ $donnees['hematies_hlm']  = null; }
 	    if($tab[3]){ $donnees['leucocytes_hlm']= $tab[3]; }else{ $donnees['leucocytes_hlm']= null; }
+	    if($tab[4]){ $donnees['commentaire_hlm_compte_daddis']= $tab[4]; }else{ $donnees['commentaire_hlm_compte_daddis']= null; }
 	
 	    if($tab[2] || $tab[3]){ $donneesExiste = 1; }
 	
@@ -3332,6 +3347,7 @@ class ResultatDemandeAnalyseTable {
 	    if($tab[3]){ $donnees['toxoplasmose_igm_titre'] = $tab[3]; }else{ $donnees['toxoplasmose_igm_titre'] = null; }
 	    if($tab[4]){ $donnees['toxoplasmose_igg']       = $tab[4]; }else{ $donnees['toxoplasmose_igg']       = null; }
 	    if($tab[5]){ $donnees['toxoplasmose_igg_titre'] = $tab[5]; }else{ $donnees['toxoplasmose_igg_titre'] = null; }
+	    if($tab[6]){ $donnees['toxoplasmose_commentaire'] = $tab[6]; }else{ $donnees['toxoplasmose_commentaire'] = null; }
 	
 	    if($tab[2] || $tab[4]){ $donneesExiste = 1; }
 	
@@ -3392,8 +3408,9 @@ class ResultatDemandeAnalyseTable {
 	    if($tab[3]){ $donnees['rubeole_igm_titre'] = $tab[3]; }else{ $donnees['rubeole_igm_titre'] = null; }
 	    if($tab[4]){ $donnees['rubeole_igg']       = $tab[4]; }else{ $donnees['rubeole_igg']       = null; }
 	    if($tab[5]){ $donnees['rubeole_igg_titre'] = $tab[5]; }else{ $donnees['rubeole_igg_titre'] = null; }
-	    
+	    if($tab[6]){ $donnees['rubeole_commentaire'] = $tab[6]; }else{ $donnees['rubeole_commentaire'] = null; }
 	
+	    
 	    if($tab[2] || $tab[4]){ $donneesExiste = 1; }
 	
 	    //Si les resultats n y sont pas on les ajoute
@@ -3903,8 +3920,10 @@ class ResultatDemandeAnalyseTable {
 		$select->join(array('t'=>'type_analyse') ,'t.idtype = a.idtype_analyse', array('Libelle'=>'libelle'));
 		$select->join(array('r'=>'resultat_demande_analyse'), 'd.iddemande = r.iddemande_analyse', array('DateEnregistrementResultat'=>'date'));
 		$select->join(array('p'=>'personne'), 'p.idpersonne = r.idemploye', array('Nom'=>'nom', 'Prenom'=>'prenom'));
-
 		$select->join(array('p2'=>'personne'), 'p2.idpersonne = r.valider_par', array('NomValidateur'=>'nom', 'PrenomValidateur'=>'prenom'));
+		
+		$select->join(array('f'=>'facturation_demande_analyse'), 'f.iddemande_analyse = d.iddemande', array('IdFacturation'=>'idfacturation'));
+		$select->join(array('b'=>'bilan_prelevement'), 'b.idfacturation = f.idfacturation', array('DateHeurePrelevement'=>'date_heure', 'DatePrelevement'=>'date_prelevement'));
 		
 		$select->where(array('d.date' => $dateDemande['date'], 'd.idpatient' => $dateDemande['idpatient'], 'r.valide' => 1));
 		$select->order(array('idanalyse' => 'ASC', 'idtype' =>'ASC'));

--- a/module/Laboratoire/src/Laboratoire/View/Helper/ImprimerResultatsAnalysesDemandees.php
+++ b/module/Laboratoire/src/Laboratoire/View/Helper/ImprimerResultatsAnalysesDemandees.php
@@ -1,0 +1,4501 @@
+<?php
+namespace Laboratoire\View\Helper;
+
+use Laboratoire\View\Helper\fpdf181\fpdf;
+use Secretariat\View\Helper\DateHelper;
+
+class ImprimerResultatsAnalysesDemandees extends fpdf
+{
+	
+	/**
+	 * ZONE DE FONCTIONS PREDEFINIES --- ZONE DE FONCTIONS PREDEFINIES --- ZONE DE FONCTIONS PREDEFINIES
+	 * ZONE DE FONCTIONS PREDEFINIES --- ZONE DE FONCTIONS PREDEFINIES --- ZONE DE FONCTIONS PREDEFINIES
+	 */
+	protected $B = 0;
+	protected $I = 0;
+	protected $U = 0;
+	protected $HREF = '';
+	
+	function WriteHTML($html)
+	{
+		// Parseur HTML
+		$html = str_replace("\n",' ',$html);
+		$a = preg_split('/<(.*)>/U',$html,-1,PREG_SPLIT_DELIM_CAPTURE);
+		foreach($a as $i=>$e)
+		{
+			if($i%2==0)
+			{
+				// Texte
+				if($this->HREF)
+					$this->PutLink($this->HREF,$e);
+				else
+					$this->Write(5,$e);
+			}
+			else
+			{
+				// Balise
+				if($e[0]=='/')
+					$this->CloseTag(strtoupper(substr($e,1)));
+				else
+				{
+					// Extraction des attributs
+					$a2 = explode(' ',$e);
+					$tag = strtoupper(array_shift($a2));
+					$attr = array();
+					foreach($a2 as $v)
+					{
+						if(preg_match('/([^=]*)=["\']?([^"\']*)/',$v,$a3))
+							$attr[strtoupper($a3[1])] = $a3[2];
+					}
+					$this->OpenTag($tag,$attr);
+				}
+			}
+		}
+	}
+	
+	function OpenTag($tag, $attr)
+	{
+		// Balise ouvrante
+		if($tag=='B' || $tag=='I' || $tag=='U')
+			$this->SetStyle($tag,true);
+		if($tag=='A')
+			$this->HREF = $attr['HREF'];
+		if($tag=='BR')
+			$this->Ln(5);
+	}
+	
+	function CloseTag($tag)
+	{
+		// Balise fermante
+		if($tag=='B' || $tag=='I' || $tag=='U')
+			$this->SetStyle($tag,false);
+		if($tag=='A')
+			$this->HREF = '';
+	}
+	
+	function SetStyle($tag, $enable)
+	{
+		// Modifie le style et sélectionne la police correspondante
+		$this->$tag += ($enable ? 1 : -1);
+		$style = '';
+		foreach(array('B', 'I', 'U') as $s)
+		{
+			if($this->$s>0)
+				$style .= $s;
+		}
+		$this->SetFont('',$style);
+	}
+	
+	function PutLink($URL, $txt)
+	{
+		// Place un hyperlien
+		$this->SetTextColor(0,0,255);
+		$this->SetStyle('U',true);
+		$this->Write(5,$txt,$URL);
+		$this->SetStyle('U',false);
+		$this->SetTextColor(0);
+	}
+	
+	
+	/**
+	 * Draws text within a box defined by width = w, height = h, and aligns
+	 * the text vertically within the box ($valign = M/B/T for middle, bottom, or top)
+	 * Also, aligns the text horizontally ($align = L/C/R/J for left, centered, right or justified)
+	 * drawTextBox uses drawRows
+	 *
+	 * This function is provided by TUFaT.com
+	 */
+	function drawTextBox($strText, $w, $h, $align='L', $valign='T', $border=true)
+	{
+		$xi=$this->GetX();
+		$yi=$this->GetY();
+	
+		$hrow=$this->FontSize;
+		$textrows=$this->drawRows($w, $hrow, $strText, 0, $align, 0, 0, 0);
+		$maxrows=floor($h/$this->FontSize);
+		$rows=min($textrows, $maxrows);
+	
+		$dy=0;
+		if (strtoupper($valign)=='M')
+			$dy=($h-$rows*$this->FontSize)/2;
+		if (strtoupper($valign)=='B')
+			$dy=$h-$rows*$this->FontSize;
+	
+		$this->SetY($yi+$dy);
+		$this->SetX($xi);
+	
+		$this->drawRows($w, $hrow, $strText, 0, $align, false, $rows, 1);
+	
+		if ($border)
+			$this->Rect($xi, $yi, $w, $h);
+	}
+	
+	function drawRows($w, $h, $txt, $border=0, $align='J', $fill=false, $maxline=0, $prn=0)
+	{
+		$cw=&$this->CurrentFont['cw'];
+		if($w==0)
+			$w=$this->w-$this->rMargin-$this->x;
+		$wmax=($w-2*$this->cMargin)*1000/$this->FontSize;
+		$s=str_replace("\r", '', $txt);
+		$nb=strlen($s);
+		if($nb>0 && $s[$nb-1]=="\n")
+			$nb--;
+		$b=0;
+		if($border)
+		{
+			if($border==1)
+			{
+				$border='LTRB';
+				$b='LRT';
+				$b2='LR';
+			}
+			else
+			{
+				$b2='';
+				if(is_int(strpos($border, 'L')))
+					$b2.='L';
+				if(is_int(strpos($border, 'R')))
+					$b2.='R';
+				$b=is_int(strpos($border, 'T')) ? $b2.'T' : $b2;
+			}
+		}
+		$sep=-1;
+		$i=0;
+		$j=0;
+		$l=0;
+		$ns=0;
+		$nl=1;
+		while($i<$nb)
+		{
+			//Get next character
+			$c=$s[$i];
+			if($c=="\n")
+			{
+				//Explicit line break
+				if($this->ws>0)
+				{
+					$this->ws=0;
+					if ($prn==1) $this->_out('0 Tw');
+				}
+				if ($prn==1) {
+					$this->Cell($w, $h, substr($s, $j, $i-$j), $b, 2, $align, $fill);
+				}
+				$i++;
+				$sep=-1;
+				$j=$i;
+				$l=0;
+				$ns=0;
+				$nl++;
+				if($border && $nl==2)
+					$b=$b2;
+				if ( $maxline && $nl > $maxline )
+					return substr($s, $i);
+				continue;
+			}
+			if($c==' ')
+			{
+				$sep=$i;
+				$ls=$l;
+				$ns++;
+			}
+			$l+=$cw[$c];
+			if($l>$wmax)
+			{
+				//Automatic line break
+				if($sep==-1)
+				{
+					if($i==$j)
+						$i++;
+					if($this->ws>0)
+					{
+						$this->ws=0;
+						if ($prn==1) $this->_out('0 Tw');
+					}
+					if ($prn==1) {
+						$this->Cell($w, $h, substr($s, $j, $i-$j), $b, 2, $align, $fill);
+					}
+				}
+				else
+				{
+					if($align=='J')
+					{
+						$this->ws=($ns>1) ? ($wmax-$ls)/1000*$this->FontSize/($ns-1) : 0;
+						if ($prn==1) $this->_out(sprintf('%.3F Tw', $this->ws*$this->k));
+					}
+					if ($prn==1){
+						$this->Cell($w, $h, substr($s, $j, $sep-$j), $b, 2, $align, $fill);
+					}
+					$i=$sep+1;
+				}
+				$sep=-1;
+				$j=$i;
+				$l=0;
+				$ns=0;
+				$nl++;
+				if($border && $nl==2)
+					$b=$b2;
+				if ( $maxline && $nl > $maxline )
+					return substr($s, $i);
+			}
+			else
+				$i++;
+		}
+		//Last chunk
+		if($this->ws>0)
+		{
+			$this->ws=0;
+			if ($prn==1) $this->_out('0 Tw');
+		}
+		if($border && is_int(strpos($border, 'B')))
+			$b.='B';
+		if ($prn==1) {
+			$this->Cell($w, $h, substr($s, $j, $i-$j), $b, 2, $align, $fill);
+		}
+		$this->x=$this->lMargin;
+		return $nl;
+	}
+	
+	
+	/**
+	 * ZONE DE FONCTIONS PREDEFINIES --- ZONE DE FONCTIONS PREDEFINIES --- ZONE DE FONCTIONS PREDEFINIES
+	 * ZONE DE FONCTIONS PREDEFINIES --- ZONE DE FONCTIONS PREDEFINIES --- ZONE DE FONCTIONS PREDEFINIES
+	 */
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	protected function nbJours($debut, $fin) {
+		//60 secondes X 60 minutes X 24 heures dans une journee
+		$nbSecondes = 60*60*24;
+	
+		$debut_ts = strtotime($debut);
+		$fin_ts = strtotime($fin);
+		$diff = $fin_ts - $debut_ts;
+		return ($diff / $nbSecondes);
+	}
+	
+	public function moisEnLettre($mois){
+		$lesMois = array('','Janvier','Fevrier','Mars','Avril',
+				'Mais','Juin','Juillet','Aout','Septembre','Octobre','Novembre','Decembre');
+		return $lesMois[$mois];
+	}
+	
+	function EnTetePage()
+	{
+		$convertDate = new DateHelper();
+		
+		$this->SetFont('Times','',10.3);
+		$this->SetTextColor(0,0,0);
+		$this->Cell(0,4,"République du Sénégal");
+		$this->SetFont('Times','',8.5);
+		$this->Cell(0,4,"",0,0,'R');
+		$this->SetFont('Times','',10.3);
+		$this->Ln(5.4);
+		$this->Cell(100,4,"Université Gaston Berger de Saint-Louis / UFR-S2");
+	
+		$this->AddFont('timesbi','','timesbi.php');
+		$this->Ln(5.4);
+		$this->Cell(100,4,"Centre de Recherche et de Prise en Charge -");
+		$this->Ln(5.4);
+		$this->SetFont('times','',10.3);
+		$this->Cell(86,4,"Ambulatoire de la Drépanocytose (CERPAD) ",0,0,'L');
+		$this->SetFont('Times','',10.3);
+		$this->Cell(14,4,'',0,0,'L');
+	
+		$this->Ln(11);
+		$this->SetFont('Times','',15);
+		$this->SetTextColor(0,128,0);
+		$this->Cell(0,-3,"RESULTATS D'ANALYSES",0,0,'C');
+		$this->Ln(1);
+		$this->SetFont('Times','',12.3);
+		$this->SetFillColor(0,128,0);
+		$this->Cell(0,0.3,"",0,1,'C',true);
+	
+		// EMPLACEMENT DU LOGO
+		// EMPLACEMENT DU LOGO
+		$baseUrl = $_SERVER['SCRIPT_FILENAME'];
+		$tabURI  = explode('public', $baseUrl);
+		$this->Image($tabURI[0].'public/images_icons/CERPAD_UGB_LOGO_M.png', 162, 12, 35, 22);
+	
+		// EMPLACEMENT DES INFORMATIONS SUR LE PATIENT
+		// EMPLACEMENT DES INFORMATIONS SUR LE PATIENT
+		$infoPatients = $this->getInfosPatients();
+		$patient = $this->getPatient();
+		$this->SetFont('Times','',10);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(1);
+		
+		$this->Cell(30,4,$patient->numero_dossier,0,0,'L',false);
+		$this->SetFont('Times','B',9);
+		$this->Cell(60,4,"PRENOM & NOM :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(92,4,iconv ('UTF-8' , 'windows-1252', $infoPatients->prenom).' '.iconv ('UTF-8' , 'windows-1252', $infoPatients->nom),0,0,'L'); }
+	
+		$this->SetFont('Times','B',9);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(5);
+		$this->Cell(90,4,"SEXE :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(92,4,iconv ('UTF-8' , 'windows-1252', $infoPatients->sexe),0,0,'L'); }
+	
+		//GESTION DES AGES
+		//GESTION DES AGES
+		$this->SetFont('Times','B',9);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(5);
+		$aujourdhui = (new \DateTime() ) ->format('Y-m-d');
+		
+		
+		$date_naissance = $infoPatients->date_naissance;
+		if($date_naissance){ $date_naissance = $convertDate->convertDate($date_naissance); } else {$date_naissance = null; }
+		if($date_naissance){
+			$this->Cell(90,4,"DATE DE NAISSANCE :",0,0,'R',false);
+			$this->SetFont('Times','',11);
+			
+			$age = $infoPatients->age;
+			if(!$age){
+			
+				$age_jours = $this->nbJours($infoPatients->date_naissance, $aujourdhui);
+				if($age_jours < 31) {
+					$age = $age_jours." jours";
+				}
+				else
+				if($age_jours >= 31) {
+					$nb_mois = (int)($age_jours/30);
+					$nb_jours = $age_jours - ($nb_mois*30);
+					$age = $nb_mois."m ".$nb_jours."j";
+				}
+			
+			}else{
+			
+				$age = $age." ans";
+			
+			}
+			
+			$this->Cell(92,4,$age,0,0,'L');
+		}else{
+			
+			$this->Cell(90,4,"AGE :",0,0,'R',false);
+			$this->SetFont('Times','',11);
+			$this->Cell(92,4,$infoPatients->age.' ans',0,0,'L');
+		}
+
+	
+		
+		$this->SetFont('Times','B',9);
+		$this->SetTextColor(0,0,0);
+		$this->Ln(5);
+		$this->Cell(90,4,"TELEPHONE :",0,0,'R',false);
+		$this->SetFont('Times','',11);
+		if($infoPatients){ $this->Cell(72,4,$infoPatients->telephone,0,0,'L'); }
+	
+		$this->Ln(5);
+		$this->SetFillColor(0,128,0);
+		$this->Cell(0,0.3,"",0,1,'C',true);
+	
+		$this->Ln(2);
+		$this->AddFont('timesi','','timesi.php');
+		$this->SetFont('timesi','',8);
+		$this->Cell(183,1,"Imprimé le : ".$convertDate->convertDate($aujourdhui),0,1,'R');
+	}
+	
+	function Footer()
+	{
+		// Positionnement à 1,5 cm du bas
+		$this->SetY(-15);
+		
+		$this->SetFillColor(0,128,0);
+		$this->Cell(0,0.3,"",0,1,'C',true);
+		$this->SetTextColor(0,0,0);
+		$this->SetFont('Times','',9.5);
+		$this->Cell(81,5,'Téléphone: 33 726 25 36 ',0,0,'L',false);
+		$this->SetTextColor(128);
+		$this->SetFont('Times','I',9);
+		$this->Cell(20,8,'Page '.$this->PageNo(),0,0,'C',false);
+		$this->SetTextColor(0,0,0);
+		$this->SetFont('Times','',9.5);
+		$this->Cell(81,5,'SIMENS+: www.simens.sn',0,0,'R',false);
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	protected $infosPatients;
+	protected $patient;
+	protected $nomService;
+	protected $depistage;
+	protected $analysesDemandees;
+	protected $resultatsAnalysesDemandees; 
+	protected $anterioriteNfs;
+	
+	public function getNomService()
+	{
+		return $this->nomService;
+	}
+	
+	public function setNomService($nomService)
+	{
+		$this->nomService = $nomService;
+	}
+	
+	public function getInfosPatients()
+	{
+		return $this->infosPatients;
+	}
+	
+	public function setInfosPatients($infosPatients)
+	{
+		$this->infosPatients = $infosPatients;
+	}
+	
+	public function getPatient()
+	{
+		return $this->patient;
+	}
+	
+	public function setPatient($patient)
+	{
+		$this->patient = $patient;
+	}
+	
+	public function getDepistage()
+	{
+		return $this->depistage;
+	}
+	
+	public function setDepistage($depistage)
+	{
+		$this->depistage = $depistage;
+	}
+	
+	public function getAnalysesDemandees()
+	{
+		return $this->analysesDemandees;
+	}
+	
+	public function setAnalysesDemandees($analysesDemandees)
+	{
+		$this->analysesDemandees = $analysesDemandees;
+	}
+	
+	public function getResultatsAnalysesDemandees()
+	{
+		return $this->resultatsAnalysesDemandees;
+	}
+	
+	public function setResultatsAnalysesDemandees($resultatsAnalysesDemandees)
+	{
+		$this->resultatsAnalysesDemandees = $resultatsAnalysesDemandees;
+	}
+	
+	public function getAnterioriteNfs()
+	{
+		return $this->anterioriteNfs;
+	}
+	
+	public function setAnterioriteNfs($anterioriteNfs)
+	{
+		$this->anterioriteNfs = $anterioriteNfs;
+	}
+	
+	
+	
+	protected $analysesImmunoHemato;
+	protected $analysesCytologie;
+	protected $analysesHemostase;
+	protected $analysesTypageHemoProteine;
+	protected $analysesMetabolismeGlucidique;
+	protected $analysesBilanLipidique;
+	protected $analysesBilanHepatique;
+	protected $analysesBilanRenal;
+	protected $analysesSerologie;
+	protected $analysesMetabolismeFer;
+	protected $analysesMetabolismeProtidique;
+	protected $analysesBilanElectrolyte;
+	protected $analysesTypageHemoglobine;
+	
+
+	public function setAnalysesImmunoHemato($analysesImmunoHemato){
+		$this->analysesImmunoHemato = $analysesImmunoHemato;
+	}
+	
+	public function getAnalysesImmunoHemato(){
+		return $this->analysesImmunoHemato;
+	}
+	
+	public function setAnalysesCytologie($analysesCytologie){
+		$this->analysesCytologie = $analysesCytologie;
+	}
+	
+	public function getAnalysesCytologie(){
+		return $this->analysesCytologie;
+	}
+	
+	public function setAnalysesHemostase($analysesHemostase){
+		$this->analysesHemostase = $analysesHemostase;
+	}
+	
+	public function getAnalysesHemostase(){
+		return $this->analysesHemostase;
+	}
+	
+	public function setAnalysesTypageHemoProteine($analysesTypageHemoProteine){
+		$this->analysesTypageHemoProteine = $analysesTypageHemoProteine;
+	}
+	
+	public function getAnalysesTypageHemoProteine(){
+		return $this->analysesTypageHemoProteine;
+	}
+	
+	public function setAnalysesMetabolismeGlucidique($analysesMetabolismeGlucidique){
+		$this->analysesMetabolismeGlucidique = $analysesMetabolismeGlucidique;
+	}
+	
+	public function getAnalysesMetabolismeGlucidique(){
+		return $this->analysesMetabolismeGlucidique;
+	}
+	
+	public function setAnalysesBilanLipidique($analysesBilanLipidique){
+		$this->analysesBilanLipidique = $analysesBilanLipidique;
+	}
+	
+	public function getAnalysesBilanLipidique(){
+		return $this->analysesBilanLipidique;
+	}
+	
+	public function setAnalysesBilanHepatique($analysesBilanHepatique){
+		$this->analysesBilanHepatique = $analysesBilanHepatique;
+	}
+	
+	public function getAnalysesBilanHepatique(){
+		return $this->analysesBilanHepatique;
+	}
+	
+	public function setAnalysesBilanRenal($analysesBilanRenal){
+		$this->analysesBilanRenal = $analysesBilanRenal;
+	}
+	
+	public function getAnalysesBilanRenal(){
+		return $this->analysesBilanRenal;
+	}
+	
+	public function setAnalysesSerologie($analysesSerologie){
+		$this->analysesSerologie = $analysesSerologie;
+	}
+	
+	public function getAnalysesSerologie(){
+		return $this->analysesSerologie;
+	}
+	
+	public function setAnalysesMetabolismeFer($analysesMetabolismeFer){
+		$this->analysesMetabolismeFer = $analysesMetabolismeFer;
+	}
+	
+	public function getAnalysesMetabolismeFer(){
+		return $this->analysesMetabolismeFer;
+	}
+	
+	public function setAnalysesMetabolismeProtidique($analysesMetabolismeProtidique){
+		$this->analysesMetabolismeProtidique = $analysesMetabolismeProtidique;
+	}
+	
+	public function getAnalysesMetabolismeProtidique(){
+		return $this->analysesMetabolismeProtidique;
+	}
+	
+	public function setAnalysesBilanElectrolyte($analysesBilanElectrolyte){
+		$this->analysesBilanElectrolyte = $analysesBilanElectrolyte;
+	}
+	
+	public function getAnalysesBilanElectrolyte(){
+		return $this->analysesBilanElectrolyte;
+	}
+	
+	public function setAnalysesTypageHemoglobine($analysesTypageHemoglobine){
+		$this->analysesTypageHemoglobine = $analysesTypageHemoglobine;
+	}
+	
+	public function getAnalysesTypageHemoglobine(){
+		return $this->analysesTypageHemoglobine;
+	}
+	
+	
+	//Premiere page NFS --- NFS --- NFS
+	//Premiere page NFS --- NFS --- NFS
+	function affichageResultatAnalyseNFS()
+	{
+		$this->AddPage();
+		$this->EnTetePage();
+		$this->afficherResultatAnalyseNFS();
+		
+	}
+	
+	//Autres pages des autres analyses demandées
+	//Autres pages des autres analyses demandées
+	function affichageResultatsAnalysesDemandees()
+	{
+		$this->AddPage();
+		$this->EnTetePage();
+		$this->AfficherAutreResultatAnalyse();
+	}
+
+	//Dernière page Typage hémoglobine (Profil du patient au dépistage)
+	//Dernière page Typage hémoglobine (Profil du patient au dépistage)
+	function affichageResultatsTypageHemoglobine()
+	{
+		$this->AddPage();
+		$this->EnTetePage();
+		$this->AfficherResultatsTypageHemoglobine();
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	function getLesAnterioritesNFS(){
+		
+		$tabInfosAnteriorite = array();
+		
+		//------- GESTION DES ANTERIORITES -------- GESTION DES ANTERIORITES -------
+		//------- GESTION DES ANTERIORITES -------- GESTION DES ANTERIORITES -------
+		//------- GESTION DES ANTERIORITES -------- GESTION DES ANTERIORITES -------
+		
+		$anterioriteNfs = $this->getAnterioriteNfs();
+		 
+		if($anterioriteNfs){
+			$controle = new DateHelper();
+			$tabInfosAnteriorite['date_anteriorite'] = $controle->convertDate($anterioriteNfs['demande']['date']);
+				 
+			//Champ1  --- Champ1  --- Champ1
+			$tabInfosAnteriorite['leucocytes'] = $anterioriteNfs['resultat']['champ1'];
+			 
+			//Champ2  --- Champ2  --- Champ2
+			$tabInfosAnteriorite['p_neutrophiles'] = $anterioriteNfs['resultat']['champ2'];
+			 
+			//Champ3  --- Champ3  --- Champ3
+			$tabInfosAnteriorite['p_eosinophiles'] = $anterioriteNfs['resultat']['champ3'];
+		
+			//Champ4  --- Champ4  --- Champ4
+			$tabInfosAnteriorite['p_basophiles'] = $anterioriteNfs['resultat']['champ4'];
+			 
+			//Champ5  --- Champ5  --- Champ5
+			$tabInfosAnteriorite['lymphocytes'] = $anterioriteNfs['resultat']['champ5'];
+			 
+			//Champ6  --- Champ6  --- Champ6
+			$tabInfosAnteriorite['monocytes'] = $anterioriteNfs['resultat']['champ6'];
+			 
+			//-----------------------------------------------------------
+			//-----------------------------------------------------------
+			 
+			//Champ12  --- Champ12  --- Champ12
+			$tabInfosAnteriorite['hematies'] = $anterioriteNfs['resultat']['champ12'];
+			 
+			//Champ13  --- Champ13  --- Champ13
+			$tabInfosAnteriorite['hemoglobines'] = $anterioriteNfs['resultat']['champ13'];
+			 
+			//Champ14  --- Champ14  --- Champ14
+			$tabInfosAnteriorite['hematocrites'] = $anterioriteNfs['resultat']['champ14'];
+			 
+			//Champ15 --- Champ15 --- Champ15
+			$tabInfosAnteriorite['vgm'] = $anterioriteNfs['resultat']['champ15'];
+			 
+			//Champ16  --- Champ16  --- Champ16
+			$tabInfosAnteriorite['tcmh'] = $anterioriteNfs['resultat']['champ16'];
+			 
+			//Champ17  --- Champ17  --- Champ17
+			$tabInfosAnteriorite['ccmh'] = $anterioriteNfs['resultat']['champ17'];
+			 
+			//Champ18  --- Champ18  --- Champ18
+			$tabInfosAnteriorite['idr_cv'] = $anterioriteNfs['resultat']['champ18'];
+			 
+			//Champ19  --- Champ19  --- Champ19
+			$tabInfosAnteriorite['idr_ds'] = $anterioriteNfs['resultat']['champ19'];
+			 
+			//--------------------------------------------------------
+			//--------------------------------------------------------
+			 
+			//Champ20 --- Champ20 --- Champ20
+			$tabInfosAnteriorite['plaquettes'] = $anterioriteNfs['resultat']['champ20'];
+			 
+			//Champ21 --- Champ21 --- Champ21
+			$tabInfosAnteriorite['vmp'] = $anterioriteNfs['resultat']['champ21'];
+			 
+			//Champ22 --- Champ22 --- Champ22
+			$tabInfosAnteriorite['idp'] = $anterioriteNfs['resultat']['champ22'];
+			 
+			//Champ23 --- Champ23 --- Champ23
+			$tabInfosAnteriorite['pct'] = $anterioriteNfs['resultat']['champ23'];
+			 
+			//Champ24 --- Champ24 --- Champ24
+			$tabInfosAnteriorite['reticulocytes'] = $anterioriteNfs['resultat']['champ24'];
+			 
+			 return $tabInfosAnteriorite;
+		}else{
+			
+			return null;
+		}
+		 
+		//GESTION DES RESULTATS DE L'ANALYSE
+		//GESTION DES RESULTATS DE L'ANALYSE
+		//GESTION DES RESULTATS DE L'ANALYSE
+	}
+	
+	function afficherResultatAnalyseNFS()
+	{
+		$controle = new DateHelper();
+		$this->AddFont('zap','','zapfdingbats.php');
+		$this->AddFont('timesb','','timesb.php');
+		$this->AddFont('timesi','','timesi.php');
+		$this->AddFont('times','','times.php');
+	
+		$resultats = $this->getResultatsAnalysesDemandees();
+		$listeAnalysesDemandees = $this->getAnalysesDemandees();
+		$infosAnalyseDemande = array();
+		
+		for($i = 0 ; $i < count($listeAnalysesDemandees) ; $i++){
+			$idanalyse = $listeAnalysesDemandees[$i]['idanalyse'];
+
+	 	    if($idanalyse == 1){
+	 	    	$analyses[$idanalyse]            = $listeAnalysesDemandees[$i]['Designation'];
+	 	    	$idAnalyses[$idanalyse]          = $idanalyse;
+	 	    	$typesAnalyses[$idanalyse]       = $listeAnalysesDemandees[$i]['Libelle'];
+	 	    	$infosAnalyseDemande[$idanalyse] = $listeAnalysesDemandees[$i];
+	 	    }
+		}
+		
+		//Date de prelèvement
+		$datePrelevement = $infosAnalyseDemande[1]['DateHeurePrelevement'];
+		
+		//Affichage des infos sur le biologiste et le technicien
+		$dateEnregistrement  =  $controle->convertDateTime($infosAnalyseDemande[1]['DateEnregistrementResultat']);
+		$prenomNomTechnicien = $infosAnalyseDemande[1]['Prenom'].' '.$infosAnalyseDemande[1]['Nom'];
+		$prenomNomBiologiste = $infosAnalyseDemande[1]['PrenomValidateur'].' '.$infosAnalyseDemande[1]['NomValidateur'];
+		
+		$this->SetFont('times','',8);
+		//$this->Cell(45,-1,'Enregistré le : '.$dateEnregistrement,'',0,'L',0);
+		$this->Cell(45,-1,'Prélèvement effectué le : '.$datePrelevement,'',0,'L',0);
+		//$this->Cell(90,-1,'par : '.$prenomNomTechnicien.' ; validé par : '.$prenomNomBiologiste,'',1,'L',0);
+		$this->Cell(90,-1,'','',1,'L',0);
+		$this->Ln(5);
+		
+		//AFFICHAGE DE L'EN TETE DU TEXTE
+		//AFFICHAGE DE L'EN TETE DU TEXTE
+		$this->SetFillColor(249,249,249);
+		$this->SetDrawColor(220,220,220);
+	
+		$this->SetFont('times','I',9);
+		$this->Cell(35,7,'Hématologie','',0,'L',0);
+		$this->SetFont('times','U',10);
+		$this->Cell(115,7,'HEMOGRAMME','',0,'C',0);
+		$this->Cell(35,7,'','',1,'C',0);
+		
+		$this->Ln(3);
+		
+		//matériel utilisé --- matériel utilisé --- matériel utilisé
+		$this->SetFont('zap','',11.3);
+		$this->Cell(4,6,' ^','BT',0,'C',1);
+		$this->SetFont('times','',11);
+		$this->Cell(181,6,'Type de matériel utilisé : '.$resultats[1]['type_materiel'],'BT',1,'L',1);
+		
+		$this->Ln(4);
+		
+		/**
+		 * ===================================================================
+		 */
+		//EN TETE DES DU TABLEAU DES INFORMATIONS A AFFICHER SUR LES RESULTATS
+		//EN TETE DES DU TABLEAU DES INFORMATIONS A AFFICHER SUR LES RESULTATS
+		/**
+		 * ===================================================================
+		 */
+		
+		$infoAnteriorite = $this->getLesAnterioritesNFS();
+		if($infoAnteriorite){ $dateAnteriorite = $infoAnteriorite['date_anteriorite']; }else{ $dateAnteriorite = "Néant"; }
+		
+		$this->SetFont('times','B',8);
+		$this->Cell(5,6,'','',0,'L',0);
+		$this->Cell(35,6,'LIBELLE','',0,'L',0);
+		$this->Cell(55,6,'VALEUR ACTUELLE','L',0,'L',0);
+		$this->Cell(50,6,'VALEUR DE REFERENCE','L',0,'L',0);
+		$this->Cell(22,6,'ANTERIORITE','L',0,'L',0);
+		$this->SetFont('times','I',9);
+		$this->Cell(18,6,'('.$dateAnteriorite.')','',1,'L',0);
+		
+		/**
+		 * ===================================================================
+		 */
+		// FIN EN TETE DES DU TABLEAU DES INFORMATIONS A AFFICHER SUR LES RESULTATS
+		// FIN EN TETE DES DU TABLEAU DES INFORMATIONS A AFFICHER SUR LES RESULTATS
+		/**
+		 * ===================================================================
+		 */
+		
+		//GESTION DES RESULTATS DE L'ANALYSE
+		//GESTION DES RESULTATS DE L'ANALYSE
+		//GESTION DES RESULTATS DE L'ANALYSE
+		/**
+		 * CHAMP 1 -- Leucocytes ------ CHAMP 1 -- Leucocytes ------ CHAMP 1
+		 */
+		//Changer la couleur de la ligne
+		$this->SetFillColor(225,225,225);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->SetFont('zap','',10.5);
+		$this->Cell(5,6,'+','',0,'L',1);
+		
+		$this->SetFont('times','B',10.5);
+		$this->Cell(35,6,'Leucocytes','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ1'],0,',', ' '),'L',0,'R',1);
+		$this->Cell(8.3,6,'/mm','L',0,'L',1);
+		$this->SetFont('times','B',15.5);
+		$this->Cell(6.7,6,'³','L',0,'L',1); 
+		$this->SetFont('times','B',10.5);
+		$this->Cell(10,6,'','L',0,'R',1);
+		$this->Cell(10,6,'','L',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->Cell(50,6,'(4 000 - 10 000)','L',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){ 
+			$this->Cell(19.2,6,$infoAnteriorite['leucocytes'],'L',0,'R',1);
+			$this->Cell(8,6,'/mm','L',0,'L',1);
+			$this->SetFont('times','B',15.5);
+			$this->Cell(12,6,'³','L',0,'L',1);
+		}else{ 
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		/**
+		 * CHAMP 2 -- Polynucléaires neutrophiles ------ CHAMP 2 -- Polynucléaires neutrophiles ------ CHAMP 2
+		 */
+			  
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(246,246,246);
+		$this->SetFont('times','',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'P. Neutrophiles','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ2'],0,',', ' '),'',0,'R',1);
+		$this->Cell(8.3,6,'/mm','',0,'L',1);
+		$this->SetFont('times','',15.5);
+		$this->Cell(6.7,6,'³','',0,'L',1);
+		$this->SetFont('times','',10.5);
+		$this->Cell(10,6,$resultats[1]['champ7'],'',0,'R',1);
+		$this->Cell(10,6,'%','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->Cell(33,6,'(2 000 - 7 000)','',0,'L',1);
+		$this->Cell(17,6,'(45 - 70)','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['p_neutrophiles'],'L',0,'R',1);
+			$this->Cell(8,6,'/mm','L',0,'L',1);
+			$this->SetFont('times','',15.5);
+			$this->Cell(12,6,'³','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		/**
+		 * CHAMP 3 -- Polynucléaire éosinophiles ------ CHAMP 3 -- Polynucléaires éosinophiles ------ CHAMP 3
+		 */
+		
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(225,225,225);
+		$this->SetFont('times','',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'P. Eosinophiles','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ3'],0,',', ' '),'',0,'R',1);
+		$this->Cell(8.3,6,'/mm','',0,'L',1);
+		$this->SetFont('times','',15.5);
+		$this->Cell(6.7,6,'³','',0,'L',1);
+		$this->SetFont('times','',10.5);
+		$this->Cell(10,6,$resultats[1]['champ8'],'',0,'R',1);
+		$this->Cell(10,6,'%','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->Cell(33,6,'(20 - 500)','',0,'L',1);
+		$this->Cell(17,6,'(0 - 5)','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['p_eosinophiles'],'L',0,'R',1);
+			$this->Cell(8,6,'/mm','L',0,'L',1);
+			$this->SetFont('times','',15.5);
+			$this->Cell(12,6,'³','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		/**
+		 * CHAMP 4 -- Polynucléaires basophiles ------ CHAMP 4 -- Polynucléaire basophiles ------ CHAMP 4
+		 */
+		
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(246,246,246);
+		$this->SetFont('times','',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'P. Basophiles','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ4'],0,',', ' '),'',0,'R',1);
+		$this->Cell(8.3,6,'/mm','',0,'L',1);
+		$this->SetFont('times','',15.5);
+		$this->Cell(6.7,6,'³','',0,'L',1);
+		$this->SetFont('times','',10.5);
+		$this->Cell(10,6,$resultats[1]['champ9'],'',0,'R',1);
+		$this->Cell(10,6,'%','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->Cell(33,6,'(0 - 100)','',0,'L',1);
+		$this->Cell(17,6,'(0 - 3)','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['p_basophiles'],'L',0,'R',1);
+			$this->Cell(8,6,'/mm','L',0,'L',1);
+			$this->SetFont('times','',15.5);
+			$this->Cell(12,6,'³','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		/**
+		 * CHAMP 5 -- Lymphocytes ------ CHAMP 5 -- Lymphocytes ------ CHAMP 5
+		 */
+		
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(225,225,225);
+		$this->SetFont('times','',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'Lymphocytes','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ5'],0,',', ' '),'',0,'R',1);
+		$this->Cell(8.3,6,'/mm','',0,'L',1);
+		$this->SetFont('times','',15.5);
+		$this->Cell(6.7,6,'³','',0,'L',1);
+		$this->SetFont('times','',10.5);
+		$this->Cell(10,6,$resultats[1]['champ10'],'',0,'R',1);
+		$this->Cell(10,6,'%','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->Cell(33,6,'(800 - 4 000)','',0,'L',1);
+		$this->Cell(17,6,'(20 - 40)','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['lymphocytes'],'L',0,'R',1);
+			$this->Cell(8,6,'/mm','L',0,'L',1);
+			$this->SetFont('times','',15.5);
+			$this->Cell(12,6,'³','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		
+		/**
+		 * CHAMP 6 -- Monocytes ------ CHAMP 6 -- Monocytes ------ CHAMP 6
+		 */
+		
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(246,246,246);
+		$this->SetFont('times','',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'Monocytes','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ6'],0,',', ' '),'',0,'R',1);
+		$this->Cell(8.3,6,'/mm','',0,'L',1);
+		$this->SetFont('times','',15.5);
+		$this->Cell(6.7,6,'³','',0,'L',1);
+		$this->SetFont('times','',10.5);
+		$this->Cell(10,6,$resultats[1]['champ11'],'',0,'R',1);
+		$this->Cell(10,6,'%','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->Cell(33,6,'(120 - 1 200)','',0,'L',1);
+		$this->Cell(17,6,'(3 - 15)','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['monocytes'],'L',0,'R',1);
+			$this->Cell(8,6,'/mm','L',0,'L',1);
+			$this->SetFont('times','',15.5);
+			$this->Cell(12,6,'³','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		
+		/**
+		 * CHAMP 12 -- Hematies ------ CHAMP 12 -- Hematies ------ CHAMP 12
+		 * ON DESCEND *** ON DESCEND *** ON DESCEND
+		 */
+		
+		$this->Ln(6);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(225,225,225);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->SetFont('zap','',10.5);
+		$this->Cell(5,6,'+','',0,'L',1);
+		
+		$this->SetFont('times','B',10.5);
+		$this->Cell(35,6,'Hématies','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ12'],0,',', ' '),'',0,'R',1);
+		
+		$this->Cell(5.3,6,'10','',0,'L',1);
+		$this->SetFont('times','B',9.5);
+		$this->Cell(2.7,6,'','',0,'T',1);
+		$x = $this->GetX(); $y = $this->GetY();
+		$this->Text($x-2.5, $y+3, '6');
+		
+		$this->SetFont('times','B',10.5);
+		$this->Cell(8,6,'/mm','',0,'L',1);
+		$this->SetFont('times','B',15.5);
+		$this->Cell(3,6,'³','',0,'L',1);
+		
+		$this->SetFont('times','',10.5);
+		$this->Cell(16,6,'','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->SetFont('times','B',10.5);
+		$this->Cell(33,6,'(3,5 - 5,0)','',0,'L',1);
+		$this->Cell(17,6,'','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['hematies'],'L',0,'R',1);
+			$this->Cell(8,6,'','L',0,'L',1);
+			$this->SetFont('times','B',15.5);
+			$this->Cell(12,6,'','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		/**
+		 * CHAMP 13 -- Hémoglobine  ------ CHAMP 13 -- Hémoglobine  ------ CHAMP 13
+		 */
+		
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(246,246,246);
+		$this->SetFont('times','B',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'Hémoglobine','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ13'],0,',', ' '),'',0,'R',1);
+		$this->Cell(19,6,'g/dl','',0,'L',1);
+		
+		$this->SetFont('times','',10.5);
+		$this->Cell(16,6,'','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->SetFont('times','B',10.5);
+		$this->Cell(33,6,'(11 - 15)','',0,'L',1);
+		$this->Cell(17,6,'','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['hemoglobines'],'L',0,'R',1);
+			$this->Cell(8,6,'','L',0,'L',1);
+			$this->SetFont('times','B',15.5);
+			$this->Cell(12,6,'','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		/**
+		 * CHAMP 14 -- Hématocrite ------ CHAMP 14 -- Hématocrite ------ CHAMP 14
+		 */
+		
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(225,225,225);
+		$this->SetFont('times','',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'Hématocrite','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ14'],0,',', ' '),'',0,'R',1);
+		$this->Cell(19,6,'%','',0,'L',1);
+		
+		$this->SetFont('times','',10.5);
+		$this->Cell(16,6,'','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->SetFont('times','',10.5);
+		$this->Cell(33,6,'(37 - 47)','',0,'L',1);
+		$this->Cell(17,6,'','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['hematocrites'],'L',0,'R',1);
+			$this->Cell(8,6,'','L',0,'L',1);
+			$this->SetFont('times','',15.5);
+			$this->Cell(12,6,'','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		/**
+		 * CHAMP 15 -- V.G.M ------ CHAMP 15 -- V.G.M ------ CHAMP 15
+		 */
+		
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(246,246,246);
+		$this->SetFont('times','',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'V.G.M','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ15'],0,',', ' '),'',0,'R',1);
+		$this->Cell(19,6,'fl','',0,'L',1);
+		
+		$this->SetFont('times','',10.5);
+		$this->Cell(16,6,'','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->SetFont('times','',10.5);
+		$this->Cell(33,6,'(80 - 100)','',0,'L',1);
+		$this->Cell(17,6,'','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['vgm'],'L',0,'R',1);
+			$this->Cell(8,6,'','L',0,'L',1);
+			$this->SetFont('times','',15.5);
+			$this->Cell(12,6,'','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		/**
+		 * CHAMP 16 -- T.C.M.H ------ CHAMP 16 -- T.C.M.H ------ CHAMP 16
+		 */
+		
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(225,225,225);
+		$this->SetFont('times','',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'T.C.M.H','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ16'],0,',', ' '),'',0,'R',1);
+		$this->Cell(19,6,'pg','',0,'L',1);
+		
+		$this->SetFont('times','',10.5);
+		$this->Cell(16,6,'','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->SetFont('times','',10.5);
+		$this->Cell(33,6,'(27 - 34)','',0,'L',1);
+		$this->Cell(17,6,'','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['tcmh'],'L',0,'R',1);
+			$this->Cell(8,6,'','L',0,'L',1);
+			$this->SetFont('times','',15.5);
+			$this->Cell(12,6,'','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		/**
+		 * CHAMP 17 -- C.C.M.H ------ CHAMP 17 -- C.C.M.H ------ CHAMP 17
+		 */
+		
+
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(246,246,246);
+		$this->SetFont('times','',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'C.C.M.H','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ17'],0,',', ' '),'',0,'R',1);
+		$this->Cell(19,6,'g/dl','',0,'L',1);
+		
+		$this->SetFont('times','',10.5);
+		$this->Cell(16,6,'','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->SetFont('times','',10.5);
+		$this->Cell(33,6,'(32 - 36)','',0,'L',1);
+		$this->Cell(17,6,'','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['ccmh'],'L',0,'R',1);
+			$this->Cell(8,6,'','L',0,'L',1);
+			$this->SetFont('times','',15.5);
+			$this->Cell(12,6,'','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		/**
+		 * CHAMP 18 -- IDR-CV ------ CHAMP 18 -- IDR-CV ------ CHAMP 18
+		 */
+		
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(225,225,225);
+		$this->SetFont('times','',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'IDR-CV','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ18'],0,',', ' '),'',0,'R',1);
+		$this->Cell(19,6,'%','',0,'L',1);
+		
+		$this->SetFont('times','',10.5);
+		$this->Cell(16,6,'','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->SetFont('times','',10.5);
+		$this->Cell(33,6,'(11 - 16)','',0,'L',1);
+		$this->Cell(17,6,'','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['idr_cv'],'L',0,'R',1);
+			$this->Cell(8,6,'','L',0,'L',1);
+			$this->SetFont('times','',15.5);
+			$this->Cell(12,6,'','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		/**
+		 * CHAMP 19 -- IDR-DS ------ CHAMP 19 -- IDR-DS ------ CHAMP 19
+		 */
+		
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(246,246,246);
+		$this->SetFont('times','',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'IDR-DS','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ19'],0,',', ' '),'',0,'R',1);
+		$this->Cell(19,6,'fl','',0,'L',1);
+		
+		$this->SetFont('times','',10.5);
+		$this->Cell(16,6,'','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->SetFont('times','',10.5);
+		$this->Cell(33,6,'(35 - 56)','',0,'L',1);
+		$this->Cell(17,6,'','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['idr_ds'],'L',0,'R',1);
+			$this->Cell(8,6,'','L',0,'L',1);
+			$this->SetFont('times','',15.5);
+			$this->Cell(12,6,'','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		
+		/**
+		 * CHAMP 20 -- Plaquettes ------ CHAMP 20 -- Plaquettes ------ CHAMP 20
+		 * ON DESCEND *** ON DESCEND *** ON DESCEND
+		 */
+		
+		$this->Ln(6);
+		
+	    //Changer la couleur de la ligne
+		$this->SetFillColor(225,225,225);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->SetFont('zap','',10.5);
+		$this->Cell(5,6,'+','',0,'L',1);
+		
+		$this->SetFont('times','B',10.5);
+		$this->Cell(35,6,'Plaquettes','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ20'],0,',', ' '),'',0,'R',1);
+		
+		$this->Cell(5.3,6,'10','',0,'L',1);
+		$this->SetFont('times','B',9.5);
+		$this->Cell(2.7,6,'','',0,'T',1);
+		$x = $this->GetX(); $y = $this->GetY();
+		$this->Text($x-2.5, $y+3, '6');
+		
+		$this->SetFont('times','B',10.5);
+		$this->Cell(8,6,'/mm','',0,'L',1);
+		$this->SetFont('times','B',15.5);
+		$this->Cell(3,6,'³','',0,'L',1);
+		
+		$this->SetFont('times','',10.5);
+		$this->Cell(16,6,'','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->SetFont('times','B',10.5);
+		$this->Cell(33,6,'(150 - 450)','',0,'L',1);
+		$this->Cell(17,6,'','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['plaquettes'],'L',0,'R',1);
+			$this->Cell(8,6,'','L',0,'L',1);
+			$this->SetFont('times','B',15.5);
+			$this->Cell(12,6,'','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		/**
+		 * CHAMP 21 -- VMP ------ CHAMP 21 -- VMP ------ CHAMP 21
+		 */
+		
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(246,246,246);
+		$this->SetFont('times','',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'VMP','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ21'],0,',', ' '),'',0,'R',1);
+		$this->Cell(19,6,'fl','',0,'L',1);
+		
+		$this->SetFont('times','',10.5);
+		$this->Cell(16,6,'','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->SetFont('times','',10.5);
+		$this->Cell(33,6,'(6,5 - 12,0)','',0,'L',1);
+		$this->Cell(17,6,'','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['vmp'],'L',0,'R',1);
+			$this->Cell(8,6,'','L',0,'L',1);
+			$this->SetFont('times','',15.5);
+			$this->Cell(12,6,'','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		/**
+		 * CHAMP 22 -- IDP ------ CHAMP 22 -- IDP ------ CHAMP 22
+		 */
+		
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(225,225,225);
+		$this->SetFont('times','',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'IDP','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ22'],0,',', ' '),'',0,'R',1);
+		$this->Cell(19,6,'g/dl','',0,'L',1);
+		
+		$this->SetFont('times','',10.5);
+		$this->Cell(16,6,'','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->SetFont('times','',10.5);
+		$this->Cell(33,6,'(9,0 - 17,0)','',0,'L',1);
+		$this->Cell(17,6,'','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['idp'],'L',0,'R',1);
+			$this->Cell(8,6,'','L',0,'L',1);
+			$this->SetFont('times','',15.5);
+			$this->Cell(12,6,'','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+
+		/**
+		 * CHAMP 23 -- PCT ------ CHAMP 23 -- PCT ------ CHAMP 23
+		 */
+		
+		$this->Ln(0.5);
+		
+		//Changer la couleur de la ligne
+		$this->SetFillColor(246,246,246);
+		$this->SetFont('times','',10.5);
+		
+		/*1) Première colonne ==== Pour les libellés*/
+		$this->Cell(5,6,'','',0,'L',1);
+		$this->Cell(35,6,'PCT','',0,'L',1);
+		
+		/*2) Deuxième colonne ==== Pour les résultats*/
+		$this->Cell(20,6,number_format($resultats[1]['champ23'],2,',', ' '),'',0,'R',1);
+		$this->Cell(19,6,'%','',0,'L',1);
+		
+		$this->SetFont('times','',10.5);
+		$this->Cell(16,6,'','',0,'L',1);
+		
+		/*3) Troisième colonne ===== pour les références */
+		$this->SetFont('times','',10.5);
+		$this->Cell(33,6,'(0,108 - 0,282)','',0,'L',1);
+		$this->Cell(17,6,'','',0,'L',1);
+		
+		/*4) Quatrième colonne ===== pour les antériorités*/
+		$this->Cell(0.8,6,'','L',0,'R',0);
+		if($infoAnteriorite){
+			$this->Cell(19.2,6,$infoAnteriorite['pct'],'L',0,'R',1);
+			$this->Cell(8,6,'','L',0,'L',1);
+			$this->SetFont('times','',15.5);
+			$this->Cell(12,6,'','L',0,'L',1);
+		}else{
+			$this->Cell(39.2,6,'','L',1,'L',1);
+		}
+		
+		
+		/**
+		 * CHAMP 24 & 25 -- Taux de réticulocytes ------ CHAMP 24 & 25 -- Taux de réticulocytes ------
+		 */
+		
+		if($resultats[1]['champ24']){
+			
+			$this->ln(6);
+			
+			//Changer la couleur de la ligne
+			$this->SetFillColor(225,225,225);
+			$this->SetFont('times','B',10.5);
+			
+			/*1) Première colonne ==== Pour les libellés*/
+			$this->Cell(5,6,'','',0,'L',1);
+			$this->Cell(35,6,'Réticulocytes','',0,'L',1);
+			
+			/*2) Deuxième colonne ==== Pour les résultats*/
+			$this->Cell(20,6,number_format($resultats[1]['champ24'],0,',', ' '),'L',0,'R',1);
+			$this->Cell(8.3,6,'/mm','L',0,'L',1);
+			$this->SetFont('times','B',15.5);
+			$this->Cell(6.7,6,'³','L',0,'L',1);
+			$this->SetFont('times','B',10.5);
+			
+			$valeurReticulo = $resultats[1]['champ25'];
+			if(fmod($valeurReticulo, 1) !== 0.00){$valeurReticulo = number_format($valeurReticulo, 1, ',', ' ');}
+			$this->Cell(10,6,$valeurReticulo,'L',0,'R',1);
+			$this->Cell(10,6,'%','L',0,'L',1);
+			
+			/*3) Troisième colonne ===== pour les références */
+			$this->Cell(33,6,'(25 000 - 80 000)','L',0,'L',1);
+			$this->Cell(17,6,'(0,5 - 1,5)','',0,'L',1);
+			
+			/*4) Quatrième colonne ===== pour les antériorités*/
+			$this->Cell(0.8,6,'','L',0,'R',0);
+			if($infoAnteriorite){
+				$this->Cell(19.2,6,$infoAnteriorite['reticulocytes'],'L',0,'R',1);
+				$this->Cell(8,6,'','L',0,'L',1);
+				$this->SetFont('times','B',15.5);
+				$this->Cell(12,6,'','L',0,'L',1);
+			}else{
+				$this->Cell(39.2,6,'','L',1,'L',1);
+			}
+		}
+
+		
+		/**
+		 * ------ COMMENTAIRE ------ COMMENTAIRE ------ COMMENTAIRE -------
+		 */
+		$this->ln(3);
+		$this->SetFont('times','U',10.5);
+		$this->Cell(185,6,'Commentaire :','',1,'L',0);
+		
+		$this->SetFillColor(255,255,255);
+		$this->SetFont('times','',10.5);
+		$this->MultiCell(185,6,iconv ('UTF-8' , 'windows-1252', $resultats[1]['commentaire']),0,'J',1);
+		
+		$this->SetFont('timesi','U',9);
+		$this->Text(163, 270, 'Cachet et signature');
+		
+	}
+	
+	
+	
+	function AfficherAutreResultatAnalyse()
+	{
+		$controle = new DateHelper();
+		$this->AddFont('zap','','zapfdingbats.php');
+		$this->AddFont('timesb','','timesb.php');
+		$this->AddFont('timesi','','timesi.php');
+		$this->AddFont('times','','times.php');
+	
+		$resultats = $this->getResultatsAnalysesDemandees();
+		$listeAnalysesDemandees = $this->getAnalysesDemandees();
+		$infosAnalyseDemande = array();
+		
+		for($i = 0 ; $i < count($listeAnalysesDemandees) ; $i++){
+			$idanalyse = $listeAnalysesDemandees[$i]['idanalyse'];
+
+	 	    if($idanalyse == 1){
+	 	    	$analyses[$idanalyse]            = $listeAnalysesDemandees[$i]['Designation'];
+	 	    	$idAnalyses[$idanalyse]          = $idanalyse;
+	 	    	$typesAnalyses[$idanalyse]       = $listeAnalysesDemandees[$i]['Libelle'];
+	 	    	$infosAnalyseDemande[$idanalyse] = $listeAnalysesDemandees[$i];
+	 	    }
+		}
+		
+		
+		/**
+		 * GESTION DES RESULTATS DANS 
+		 * --- IMMUNO-HEMATOLOGIE --- IMMUNO-HEMATOLOGIE --- IMMUNO-HEMATOLOGIE
+		 */
+		$idAnalysesImmunoHemato = $this->getAnalysesImmunoHemato();
+		if($idAnalysesImmunoHemato){
+			$indice = 0;
+			$this->Ln(1);
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			$this->SetDrawColor(220,220,220);
+			
+			$this->SetFont('times','I',9);
+			$this->Cell(35,7,'','',0,'L',0);
+			$this->SetFont('times','U',10);
+			$this->Cell(115,7,'IMMUNO-HEMATOLOGIE','',0,'C',0);
+			$this->Cell(35,7,'','',1,'C',0);
+			$this->Ln(1);
+			
+			//GSRH - GROUPAGE RESHUS ---- GSRH - GROUPAGE RESHUS
+			if(in_array(2, $idAnalysesImmunoHemato)){
+				
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+				
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,'GSRH / GROUPAGE RESHUS : ','BT',0,'L',1);
+				
+				$this->SetFont('times','I',10);
+				$this->Cell(15,6,'Groupe : ','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(25,6,' '.$resultats[2]['groupe'],'BT',0,'L',1);
+				
+				$this->SetFont('times','I',10);
+				$this->Cell(15,6,'Réshus : ','BT',0,'L',1);
+				
+				$RhesusType = 'Positif';
+				if($resultats[2]['rhesus'] == 'Rh-'){ $RhesusType = 'Négatif'; }
+				$this->SetFont('times','B',11);
+				$this->Cell(65,6,' '.$RhesusType,'BT',1,'L',1);
+				
+			}
+			
+			
+			//RECHERCHE DE L'ANTIGENE D FAIBLE --- RECHERCHE DE L'ANTIGENE D FAIBLE
+			if(in_array(3, $idAnalysesImmunoHemato)){
+
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+				
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,'RECHERCHE ANTIGENE D FAIBLE : ','BT',0,'L',1);
+				
+				$rechAntDFaible = $resultats[3]['antigene_d_faible'];
+				if($rechAntDFaible == 'Negatif'){ $rechAntDFaible = 'Négatif'; }
+				
+				$this->SetFont('times','B',11.5);
+				$this->Cell(25,6,$rechAntDFaible,'BT',0,'L',1);
+				
+				if($resultats[3]['conclusion_antigene_d_faible']){
+					$this->SetFont('times','I',10);
+					$this->Cell(20,6,'Conclusion : ','BT',0,'L',1);
+					$this->SetFont('times','B',10);
+					$this->Cell(75,6,iconv ('UTF-8' , 'windows-1252', $resultats[3]['conclusion_antigene_d_faible']),'BT',1,'L',1);
+				}else{
+					$this->SetFont('times','I',10);
+					$this->Cell(20,6,'','BT',0,'L',1);
+					$this->SetFont('times','B',11);
+					$this->Cell(75,6,'','BT',1,'L',1);
+				}
+				
+			}
+			
+			
+			//TEST DE COOMBS DIRECT --- TEST DE COOMBS DIRECT --- TEST DE COOMBS DIRECT
+			if(in_array(4, $idAnalysesImmunoHemato)){
+			
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+			
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,'TEST DE COOMBS DIRECT : ','BT',0,'L',1);
+			
+				$testCoombsDirect = $resultats[4]['valeur'];
+				if($testCoombsDirect == 'Negatif'){ $testCoombsDirect = 'Négatif'; }
+				
+				$this->SetFont('times','B',11.5);
+				$this->Cell(25,6,$testCoombsDirect,'BT',0,'L',1);
+				
+				if($testCoombsDirect == 'Positif'){
+					$this->SetFont('times','I',10);
+					$this->Cell(20,6,'Titre : ','BT',0,'R',1);
+					$this->SetFont('times','B',10);
+					$this->Cell(75,6,iconv ('UTF-8' , 'windows-1252', $resultats[4]['titre']),'BT',1,'L',1);
+				}else{
+					$this->SetFont('times','I',10);
+					$this->Cell(20,6,'','BT',0,'L',1);
+					$this->SetFont('times','B',11);
+					$this->Cell(75,6,'','BT',1,'L',1);
+				}
+					
+			}
+			
+			
+			//TEST DE COOMBS INDIRECT --- TEST DE COOMBS INDIRECT --- TEST DE COOMBS INDIRECT
+			if(in_array(4, $idAnalysesImmunoHemato)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,'TEST DE COOMBS INDIRECT : ','BT',0,'L',1);
+					
+				$testCoombsInDirect = $resultats[5]['valeur'];
+				if($testCoombsInDirect == 'Negatif'){ $testCoombsInDirect = 'Négatif'; }
+			
+				$this->SetFont('times','B',11.5);
+				$this->Cell(25,6,$testCoombsInDirect,'BT',0,'L',1);
+			
+				if($testCoombsInDirect == 'Positif'){
+					$this->SetFont('times','I',10);
+					$this->Cell(20,6,'Titre : ','BT',0,'R',1);
+					$this->SetFont('times','B',10);
+					$this->Cell(75,6,iconv ('UTF-8' , 'windows-1252', $resultats[5]['titre']),'BT',1,'L',1);
+				}else{
+					$this->SetFont('times','I',10);
+					$this->Cell(20,6,'','BT',0,'L',1);
+					$this->SetFont('times','B',11);
+					$this->Cell(75,6,'','BT',1,'L',1);
+				}
+					
+					
+			}
+			
+			
+			//TEST DE COMPATIBILITE --- TEST DE COMPATIBILITE --- TEST DE COMPATIBILITE
+			if(in_array(6, $idAnalysesImmunoHemato)){
+
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,'TEST DE COMPATIBILITE : ','BT',0,'L',1);
+					
+				$testCompatibilite = $resultats[6]['valeur'];
+				
+				$this->SetFont('times','B',11.5);
+				$this->Cell(25,6,$testCompatibilite,'BT',0,'L',1);
+					
+				if($testCompatibilite == 'Compatible'){
+					$this->SetFont('times','I',10);
+					$this->Cell(33,6,'Poche numéro : ','BT',0,'R',1);
+					$this->SetFont('times','B',10);
+					$this->Cell(62,6,iconv ('UTF-8' , 'windows-1252', $resultats[6]['poche']),'BT',1,'L',1);
+				}else{
+					$this->SetFont('times','I',10);
+					$this->Cell(20,6,'','BT',0,'L',1);
+					$this->SetFont('times','B',11);
+					$this->Cell(75,6,'','BT',1,'L',1);
+				}
+					
+					
+			}
+			
+			
+		}
+		
+		
+		/**
+		 * GESTION DES RESULTATS DANS
+		 * --- CYTOLOGIE --- CYTOLOGIE --- CYTOLOGIE --- CYTOLOGIE --- CYTOLOGIE
+		 */
+		$idAnalysesCytologie = $this->getAnalysesCytologie();
+		if($idAnalysesCytologie){
+			$indice = 0;
+			$this->Ln(1);
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			$this->SetDrawColor(220,220,220);
+				
+			$this->SetFont('times','I',9);
+			$this->Cell(35,7,'','',0,'L',0);
+			$this->SetFont('times','U',10);
+			$this->Cell(115,7,'CYTOLOGIE','',0,'C',0);
+			$this->Cell(35,7,'','',1,'C',0);
+			$this->Ln(1);
+				
+			//VITESSE DE SEDIMENTATION (VS) ---- VITESSE DE SEDIMENTATION (VS)
+			if(in_array(7, $idAnalysesCytologie)){
+		
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+		
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,'VITESSE DE SEDIMENTATION (VS) : ','BT',0,'L',1);
+		
+				$this->SetFont('times','I',9);
+				$this->Cell(18,6,'1ère heure : ','BT',0,'L',1);
+		
+				$this->SetFont('times','B',11);
+				$this->Cell(22,6,$resultats[7]['valeur1'].'  mm','BT',0,'L',1);
+		
+				$this->SetFont('times','I',9);
+				$this->Cell(20,6,'2ème heure : ','BT',0,'R',1);
+		
+				$this->SetFont('times','B',11);
+				$this->Cell(30,6,$resultats[7]['valeur2'].'  mm','BT',0,'L',1);
+				
+				$this->SetFont('times','I',7);
+				$this->Cell(30,6,'( H<15 | H>20 ; +60ans < 30 )','BT',1,'R',1);
+		
+			}
+			
+			//TEST D'EMMEL (TE)  --- TEST D'EMMEL (TE)  --- TEST D'EMMEL (TE) 
+			if(in_array(8, $idAnalysesCytologie)){
+
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+				
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,"TEST D'EMMEL (TE) : ",'BT',0,'L',1);
+				
+				$testDemmel = $resultats[8]['valeur'];
+				if($testDemmel == 'Negatif'){ $testDemmel = 'Négatif'; }
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(40,6,$testDemmel,'BT',0,'L',1);
+				
+				$this->SetFont('times','I',9);
+				$this->Cell(80,6,'','BT',1,'R',1);
+				
+			}
+			
+			//HLM (COMPTE D'ADDIS)  --- HLM (COMPTE D'ADDIS) --- HLM (COMPTE D'ADDIS)
+			if(in_array(50, $idAnalysesCytologie)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','T',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(50,6,"HLM (COMPTE D'ADDIS) : ",'T',0,'L',1);
+					
+				$this->SetFont('times','I',9);
+				$this->Cell(18,6,'Hématies :','T',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(25,6,number_format($resultats[50]['hematies_hlm'], 0, ',', ' ').'  /min','T',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(20,6,'( < 2 000 )','T',0,'L',1);
+					
+				
+				$this->SetFont('times','I',9);
+				$this->Cell(18,6,'Leucocytes :','T',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(30,6,number_format($resultats[50]['leucocytes_hlm'], 0, ',', ' ').'  /min','T',0,'L',1);
+			
+				$this->SetFont('times','I',7);
+				$this->Cell(19,6,'( < 2 000 )','T',1,'L',1);
+				
+				/** Conclusion --- Conclusion --- Conclusion**/
+				/** Conclusion --- Conclusion --- Conclusion**/
+				$commentaireHLM = $resultats[50]['commentaire_hlm_compte_daddis'];
+				if($commentaireHLM){
+					$this->Cell(15,6,'','B',0,'L',1);
+					
+					$this->SetFont('timesbi','U',10);
+					$this->Cell(25,6,'Commentaire :','B',0,'R',1);
+					
+					$this->SetFont('times','B',11);
+					$this->MultiCell(145,6,iconv ('UTF-8' , 'windows-1252', $commentaireHLM),'B','J',1);
+						
+				}
+					
+			}
+
+			
+			//CULOT URINAIRE --- CULOT URINAIRE --- CULOT URINAIRE --- CULOT URINAIRE
+			if(in_array(58, $idAnalysesCytologie)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(50,6,"CULOT URINAIRE : ",'T',0,'L',1);
+					
+				
+				$listeElementsA  = array(1=>'Leucocytes', 2=>'Hématies', 3=>'Cristaux', 4=>'Oeufs', 5=>'Parasites');
+				$listeSousElemA3 = array(1=>'Oxalate de potassium | calcium', 2=>'Phosphate', 3=>'Cystine', 4=>'Acide Urique');
+				$listeSousElemA4 = array(1=>'Schistoma hematobium');
+				$listeSousElemA5 = array(1=>'Trichomonas vaginale', 2=>'Schistosoma hematobium');
+					
+				$nbElements = count($resultats[58]);
+				
+				if($nbElements > 0){
+					
+					for($i = 0 ; $i < $nbElements ; $i++){
+					
+						$valeur1 = $resultats[58][$i]['culot_urinaire_1'];
+					
+						if($i == 0){
+							$this->SetFont('times','',11);
+							$this->Cell(25,6,' » '.$listeElementsA[$valeur1].' ','T',0,'L',1);
+							
+							$valeur2Aff = "";
+							
+							if($valeur1 == 1){
+								$valeur2 = $resultats[58][$i]['culot_urinaire_2'];
+								$valeur2Aff = iconv ('UTF-8' , 'windows-1252', $valeur2);
+							}else if($valeur1 == 2){
+								$valeur2 = $resultats[58][$i]['culot_urinaire_2'];
+								$valeur2Aff = iconv ('UTF-8' , 'windows-1252', $valeur2);
+							}else if($valeur1 == 3){
+								$valeur2 = $resultats[58][$i]['culot_urinaire_2'];
+								$valeur2Aff = $listeSousElemA3[$valeur2];
+							}else if($valeur1 == 4){
+								$valeur2 = $resultats[58][$i]['culot_urinaire_2'];
+								$valeur2Aff = $listeSousElemA4[$valeur2];
+							}else if($valeur1 == 5){
+								$valeur2 = $resultats[58][$i]['culot_urinaire_2'];
+								$valeur2Aff = $listeSousElemA5[$valeur2];
+							}
+								
+							if($valeur2Aff){
+								$this->Cell(25,6,' ---------------- ','T',0,'L',1);
+							}else{
+								$this->Cell(25,6,' ','T',0,'L',1);
+							}
+							
+							$this->SetFont('times','',11);
+							$this->Cell(80,6,$valeur2Aff ,'T',1,'L',1);
+							
+						}else{
+							$this->Cell(55,6,"",'',0,'L',1);
+							
+							$this->SetFont('times','',11);
+							$this->Cell(25,6,' » '.$listeElementsA[$valeur1].' ','',0,'L',1);
+							
+							$valeur2Aff = "";
+							
+							if($valeur1 == 1){
+								$valeur2 = $resultats[58][$i]['culot_urinaire_2'];
+								$valeur2Aff = iconv ('UTF-8' , 'windows-1252', $valeur2);
+							}else if($valeur1 == 2){
+								$valeur2 = $resultats[58][$i]['culot_urinaire_2'];
+								$valeur2Aff = iconv ('UTF-8' , 'windows-1252', $valeur2);
+							}else if($valeur1 == 3){
+								$valeur2 = $resultats[58][$i]['culot_urinaire_2'];
+								$valeur2Aff = $listeSousElemA3[$valeur2];
+							}else if($valeur1 == 4){
+								$valeur2 = $resultats[58][$i]['culot_urinaire_2'];
+								$valeur2Aff = $listeSousElemA4[$valeur2];
+							}else if($valeur1 == 5){
+								$valeur2 = $resultats[58][$i]['culot_urinaire_2'];
+								$valeur2Aff = $listeSousElemA5[$valeur2];
+							}
+								
+							if($valeur2Aff){
+								$this->Cell(25,6,' ---------------- ','',0,'L',1);
+							}else{
+								$this->Cell(25,6,' ','',0,'L',1);
+							}
+							
+							$this->SetFont('times','',11);
+							$this->Cell(80,6,$valeur2Aff ,'',1,'L',1);
+						}
+						
+					
+					}
+					
+				}else{
+					$this->SetFont('times','B',11);
+					$this->Cell(130,6,'','T',1,'L',1);
+					
+				}
+				
+				
+				/** Conclusion --- Conclusion --- Conclusion**/
+				/** Conclusion --- Conclusion --- Conclusion**/
+				$this->Cell(15,6,'','B',0,'L',1);
+				
+				$this->SetFont('timesbi','U',10);
+				$this->Cell(25,6,'Conclusion :','B',0,'R',1);
+				
+				$this->SetFont('times','B',11);
+				$this->MultiCell(145,6,iconv ('UTF-8' , 'windows-1252', $resultats[58][0]['conclusion']),'B','J',1);
+					
+				
+				
+					
+			}
+			
+			
+		}
+		
+
+		/**
+		 * GESTION DES RESULTATS DANS
+		 * --- HEMOSTASE --- HEMOSTASE --- HEMOSTASE --- HEMOSTASE --- HEMOSTASE
+		 */
+		
+		$idAnalysesHemostase = $this->getAnalysesHemostase();
+		if($idAnalysesHemostase){
+			$indice = 0;
+			$this->Ln(1);
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			$this->SetDrawColor(220,220,220);
+		
+			$this->SetFont('times','I',9);
+			$this->Cell(35,7,'','',0,'L',0);
+			$this->SetFont('times','U',10);
+			$this->Cell(115,7,'HEMOSTASE','',0,'C',0);
+			$this->Cell(35,7,'','',1,'C',0);
+			$this->Ln(1);
+		
+			//TP-INR  ---  TP-INR ---  TP-INR  ---  TP-INR --- 
+			if(in_array(14, $idAnalysesHemostase)){
+		
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+		
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','T',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(22,6,'TP - INR : ','T',0,'L',1);
+		
+				//Première ligne --- Première ligne --- Première ligne
+				$this->SetFont('times','I',8);
+				$this->Cell(35,6,'Temps quick temoin : ','T',0,'L',1);
+		
+				$this->SetFont('times','B',11);
+				$this->Cell(17,6,$resultats[14]['temps_quick_temoin'].'  s','T',0,'L',1);
+		
+				$this->SetFont('times','I',8);
+				$this->Cell(20,6,'( 11 - 13 )','T',0,'R',1);
+		
+				$this->SetFont('times','B',11);
+				$this->Cell(13,6,'','T',0,'L',1);
+		
+				$this->SetFont('times','I',8);
+				$this->Cell(31,6,'Temps quick patient : ','T',0,'R',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(18,6,$resultats[14]['temps_quick_patient'].'  s','T',0,'L',1);
+				
+				$this->SetFont('times','I',8);
+				$this->Cell(8,6,'','T',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(16,6,'','T',1,'L',1);
+				
+				
+				//Deuxième ligne --- Deuxième ligne --- Deuxième ligne
+				$this->Cell(27,6,'','B',0,'L',1);
+				
+				$this->SetFont('times','I',8);
+				$this->Cell(35,6,'Taux prothrombine patient :','B',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(17,6,$resultats[14]['taux_prothrombine_patient'].'  %','B',0,'L',1);
+				
+				$this->SetFont('times','I',8);
+				$this->Cell(20,6,'( 70 - 100 )','B',0,'R',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(13,6,'','B',0,'L',1);
+				
+				$this->SetFont('times','I',8);
+				$this->Cell(31,6,'INR :','B',0,'R',1);
+				
+				$valeurINR = $resultats[14]['inr_patient'];
+				if(fmod($valeurINR, 1) !== 0.00){$valeurINR = number_format($valeurINR, 1, ',', ' ');}
+				
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(18,6,$valeurINR,'B',0,'L',1);
+				
+				$this->SetFont('times','I',8);
+				$this->Cell(8,6,'','B',0,'L',1);
+				
+				$this->SetFont('times','I',8);
+				$this->Cell(16,6,'( < 1,2 )','B',1,'L',1);
+				
+				
+				
+				
+				
+				
+				
+				
+				
+				
+				
+				
+			}
+		
+			//--- TCA  ---  TCA ---  TCA  ---  TCA  --- TCA
+			if(in_array(15, $idAnalysesHemostase)){
+			
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+			
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(22,6,'TCA : ','BT',0,'L',1);
+			
+				$this->SetFont('times','I',8);
+				$this->Cell(13,6,'Témoin : ','BT',0,'L',1);
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(17,6,$resultats[15]['temoin_patient'].' s','BT',0,'L',1);
+				
+				$this->SetFont('times','I',8);
+				$this->Cell(25,6,'Patient: ','BT',0,'R',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(17,6,$resultats[15]['tca_patient'].' s','BT',0,'L',1);
+				
+				$this->SetFont('times','I',9);
+				$this->Cell(13,6,'( 25 - 41 )','BT',0,'R',1);
+			
+				$this->SetFont('times','I',8);
+				$this->Cell(31,6,'Ratio : ','BT',0,'R',1);
+			
+				$valeurRatio = $resultats[15]['tca_patient']/$resultats[15]['temoin_patient'];
+				if(fmod($valeurRatio, 1) !== 0.00){$valeurRatio = number_format($valeurRatio, 2, ',', ' ');}
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(26,6,$valeurRatio,'BT',0,'L',1);
+			
+				$this->SetFont('times','I',8);
+				$this->Cell(16,6,'( < 1,2 )','BT',1,'L',1);
+			
+			}
+			
+			//--- FIBRINEMIE  -&-  TEMPS DE SAIGNEMENT -&-  FIBRINEMIE  -&-  TEMPS DE SAIGNEMENT
+			if(in_array(16, $idAnalysesHemostase) || in_array(17, $idAnalysesHemostase)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+					
+				$this->Ln(0.5);
+				
+				if(in_array(16, $idAnalysesHemostase)){
+					$this->SetFont('zap','',11.3);
+					$this->Cell(5,6,' +','BT',0,'C',1);
+					$this->SetFont('times','',9);
+					$this->Cell(22,6,'FIBRINEMIE : ','BT',0,'L',1);
+						
+					$this->SetFont('times','B',11);
+					$this->Cell(18,6,$resultats[16]['fibrinemie'].'  g/l','BT',0,'R',1);
+						
+					$this->SetFont('times','I',8);
+					$this->Cell(24,6,'','BT',0,'R',1);
+					$this->Cell(23,6,'( 2 - 4 g/l )','BT',0,'R',1);
+					
+					/** Séparateur --- Séparateur --- Séparateur **/
+					$this->Cell(1,6,' ','',0,'L',0);
+				}
+				
+				if(in_array(17, $idAnalysesHemostase)){
+					$this->SetFont('zap','',11.3);
+					$this->Cell(5,6,' +','BT',0,'C',1);
+					$this->SetFont('times','',9);
+					$this->Cell(42,6,'TEMPS DE SAIGNEMENT : ','BT',0,'L',1);
+						
+					$this->SetFont('times','B',11);
+					$this->Cell(18,6,$resultats[17]['temps_saignement'].'  min','BT',0,'R',1);
+						
+					$this->SetFont('times','I',8);
+					$this->Cell(27,6,'( 2 - 6 min )','BT',0,'R',1);
+				}
+				
+				//Aller à la ligne
+				$this->Cell(0,6,'','',1);
+			}
+			
+			//FACTEUR 8  -&-  FACTEUR 9  -&-  FACTEUR 8  -&-  FACTEUR 9
+			if(in_array(18, $idAnalysesHemostase) || in_array(19, $idAnalysesHemostase)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+					
+				$this->Ln(0.5);
+				
+				if(in_array(18, $idAnalysesHemostase)){
+					$this->SetFont('zap','',11.3);
+					$this->Cell(5,6,' +','BT',0,'C',1);
+					$this->SetFont('times','',9);
+					$this->Cell(22,6,'FACTEUR VIII : ','BT',0,'L',1);
+			
+					$this->SetFont('times','B',11);
+					$this->Cell(18,6,$resultats[18]['facteur_8'].' s','BT',0,'R',1);
+			
+					$this->SetFont('times','I',8);
+					$this->Cell(24,6,'','BT',0,'R',1);
+					$this->Cell(23,6,'','BT',0,'R',1);
+						
+					/** Séparateur --- Séparateur --- Séparateur **/
+					$this->Cell(1,6,' ','',0,'L',0);
+				}
+			
+				if(in_array(19, $idAnalysesHemostase)){
+					$this->SetFont('zap','',11.3);
+					$this->Cell(5,6,' +','BT',0,'C',1);
+					$this->SetFont('times','',9);
+					$this->Cell(42,6,'FACTEUR IX : ','BT',0,'L',1);
+			
+					$this->SetFont('times','B',11);
+					$this->Cell(18,6,$resultats[19]['facteur_9'].' s','BT',0,'R',1);
+			
+					$this->SetFont('times','I',8);
+					$this->Cell(27,6,'','BT',0,'R',1);
+				}
+			
+				//Aller à la ligne
+				$this->Cell(0,6,'','',1);
+			}
+			
+			//D-DIMERES  ---  D-DIMERES  ---  D-DIMERES  ---  D-DIMERES
+			if(in_array(20, $idAnalysesHemostase)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+					
+				$this->Ln(0.5);
+			
+				if(in_array(20, $idAnalysesHemostase)){
+					$this->SetFont('zap','',11.3);
+					$this->Cell(5,6,' +','BT',0,'C',1);
+					$this->SetFont('times','',9);
+					$this->Cell(22,6,'D-DIMERES : ','BT',0,'L',1);
+						
+					$this->SetFont('times','B',11);
+					$this->Cell(24,6,$resultats[20]['d_dimeres'].' ug/ml','BT',0,'R',1);
+						
+					$this->SetFont('times','I',8);
+					$this->Cell(18,6,'','BT',0,'R',1);
+					$this->Cell(23,6,'','BT',0,'R',1);
+			
+					/** Séparateur --- Séparateur --- Séparateur **/
+					$this->Cell(1,6,' ','',0,'L',0);
+				}
+					
+				/*
+				if(in_array(19, $idAnalysesHemostase)){
+					$this->SetFont('zap','',11.3);
+					$this->Cell(5,6,' +','BT',0,'C',1);
+					$this->SetFont('times','',9);
+					$this->Cell(42,6,'FACTEUR 9 : ','BT',0,'L',1);
+						
+					$this->SetFont('times','B',11);
+					$this->Cell(18,6,$resultats[19]['facteur_9'].'  ','BT',0,'R',1);
+						
+					$this->SetFont('times','I',8);
+					$this->Cell(27,6,'','BT',0,'R',1);
+				}
+				*/
+					
+				//Aller à la ligne
+				$this->Cell(0,6,'','',1);
+			}
+			
+			
+			
+			
+			
+		}
+		
+		
+		/**
+		 * GESTION DES RESULTATS DANS
+		 * --- SEROLOGIE --- SEROLOGIE --- SEROLOGIE --- SEROLOGIE --- SEROLOGIE
+		 */
+		
+		$idAnalysesSerologie = $this->getAnalysesSerologie();
+		if($idAnalysesSerologie){
+			$indice = 0;
+			$this->Ln(1);
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			$this->SetDrawColor(220,220,220);
+		
+			$this->SetFont('times','I',9);
+			$this->Cell(35,7,'','',0,'L',0);
+			$this->SetFont('times','U',10);
+			$this->Cell(115,7,'SEROLOGIE','',0,'C',0);
+			$this->Cell(35,7,'','',1,'C',0);
+			$this->Ln(1);
+		
+			//GOUTTE EPAISSE --- GOUTTE EPAISSE --- GOUTTE EPAISSE --- GOUTTE EPAISSE
+			if(in_array(10, $idAnalysesSerologie)){
+		
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+		
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','T',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,'GOUTTE EPAISSE : ','T',0,'L',1);
+					
+				$goutteEpaisse = 'Positif';
+				if($resultats[10]['goutte_epaisse'] == 'Negatif'){ $goutteEpaisse = 'Négatif'; }
+				
+				$this->SetFont('times','B',11.5);
+				$this->Cell(25,6,$goutteEpaisse,'T',0,'L',1);
+					
+				if($resultats[10]['densite_parasitaire']){
+					$this->SetFont('times','I',10);
+					$this->Cell(33,6,'Densité parasitaire : ','T',0,'R',1);
+					$this->SetFont('times','B',10);
+					$this->Cell(62,6,$resultats[10]['densite_parasitaire'].' p/ul','T',1,'L',1);
+				}else{
+					$this->SetFont('times','I',10);
+					$this->Cell(20,6,'','T',0,'L',1);
+					$this->SetFont('times','B',11);
+					$this->Cell(75,6,'','T',1,'L',1);
+				}
+				
+				/** Commentaire --- Commentaire --- Commentaire**/
+				/** Commentaire --- Commentaire --- Commentaire**/
+				$this->Cell(15,6,'','B',0,'L',1);
+				
+				$this->SetFont('timesbi','U',10);
+				$this->Cell(25,6,'Commentaire :','B',0,'R',1);
+				
+				$this->SetFont('times','B',11);
+				$this->MultiCell(145,6,iconv ('UTF-8' , 'windows-1252', $resultats[10]['commentaire_goutte_epaisse']),'B','J',1);
+				
+
+			}
+		
+			
+			//PSA --- PSA --- PSA --- PSA --- PSA --- PSA
+			if(in_array(52, $idAnalysesSerologie)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(50,6,"PSA QUALITATIF : ",'BT',0,'L',1);
+					
+				$psa_qualitatif = 'Positif';
+				if($psa_qualitatif == 'negatif'){ $psa_qualitatif = 'Négatif'; }
+				$this->SetFont('times','B',11);
+				$this->Cell(35,6,$psa_qualitatif,'BT',0,'L',1);
+				
+				$this->SetFont('times','I',9);
+				$this->Cell(13,6,'Titre :','BT',0,'L',1);
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(25,6,number_format($resultats[52]['psa'], 0, ',', ' ').'  ng/ml','BT',0,'L',1);
+					
+				$this->SetFont('times','I',9);
+				$this->Cell(38,6,'','BT',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(19,6,'','BT',1,'L',1);
+					
+			}
+			
+			
+			//CRP ou C. Protéine Réactive --- CRP ou C. Protéine Réactive --- CRP ou C. Protéine Réactive
+			if(in_array(53, $idAnalysesSerologie)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(50,6,"CRP ou C. Protéine Réactive : ",'BT',0,'L',1);
+					
+				$this->SetFont('times','I',9);
+				$this->Cell(18,6,'','BT',0,'L',1);
+					
+				$valeurCrp = 'Positif';
+				if($resultats[53]['optionResultatCrp'] == 'negatif'){ $valeurCrp = 'Négatif'; }
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$valeurCrp,'BT',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(10,6,'','BT',0,'L',1);
+					
+				if($resultats[53]['crpValeurResultat']){
+					$this->SetFont('times','B',11);
+					$this->Cell(45,6,number_format($resultats[53]['crpValeurResultat'], 0, ',', ' ').' mg/l','BT',0,'L',1);
+				}else{
+					$this->SetFont('times','B',11);
+					$this->Cell(45,6,'','BT',0,'L',1);
+				}
+
+					
+				$this->SetFont('times','I',9);
+				$this->Cell(18,6,'( < 6 mg/l )','BT',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(19,6,'','BT',1,'L',1);
+
+			}
+			
+			
+			//FACTEURS RHUMATOIDES (RF LATEX) --- FACTEURS RHUMATOIDES (RF LATEX) ---
+			if(in_array(53, $idAnalysesSerologie)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(63,6,"FACTEURS RHUMATOIDES (RF LATEX) : ",'BT',0,'L',1);
+					
+				$this->SetFont('times','I',9);
+				$this->Cell(5,6,'','BT',0,'L',1);
+					
+				$valeurFacteursRhumatoides = 'Positif';
+				if($resultats[54]['facteurs_rhumatoides'] == 'negatif'){ $valeurFacteursRhumatoides = 'Négatif'; }
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$valeurFacteursRhumatoides,'BT',0,'L',1);
+					
+				if($resultats[54]['facteurs_rhumatoides_titre']){
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'Titre :','BT',0,'L',1);
+					
+					$this->SetFont('times','B',11);
+					$this->Cell(45,6,number_format($resultats[54]['facteurs_rhumatoides_titre'], 0, ',', ' ').' UI/ml','BT',0,'L',1);
+				}else{
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'','BT',0,'L',1);
+					
+					$this->SetFont('times','B',11);
+					$this->Cell(45,6,'','BT',0,'L',1);
+				}
+			
+					
+				$this->SetFont('times','I',9);
+				$this->Cell(18,6,'( < 8 UI/ml )','BT',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(19,6,'','BT',1,'L',1);
+			
+			}
+			
+			
+			//RF WAALER ROSE --- RF WAALER ROSE --- RF WAALER ROSE --- RF WAALER ROSE
+			if(in_array(55, $idAnalysesSerologie)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(63,6,"RF WAALER ROSE : ",'BT',0,'L',1);
+					
+				$this->SetFont('times','I',9);
+				$this->Cell(5,6,'','BT',0,'L',1);
+					
+				$valeurWaalerRose = 'Positif';
+				if($resultats[55]['rf_waaler_rose'] == 'negatif'){ $valeurWaalerRose = 'Négatif'; }
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$valeurWaalerRose,'BT',0,'L',1);
+					
+				if($resultats[55]['rf_waaler_rose_titre']){
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'Titre :','BT',0,'L',1);
+						
+					$this->SetFont('times','B',11);
+					$this->Cell(45,6,number_format($resultats[55]['rf_waaler_rose_titre'], 0, ',', ' ').'  UI/ml','BT',0,'L',1);
+				}else{
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'','BT',0,'L',1);
+						
+					$this->SetFont('times','B',11);
+					$this->Cell(45,6,'','BT',0,'L',1);
+				}
+					
+					
+				$this->SetFont('times','I',9);
+				$this->Cell(18,6,'( < 8 UI/ml )','BT',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(19,6,'','BT',1,'L',1);
+					
+			}
+			
+			
+			//TOXOPLASMOSE --- TOXOPLASMOSE --- TOXOPLASMOSE --- TOXOPLASMOSE
+			if(in_array(56, $idAnalysesSerologie)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','T',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(35,6,"TOXOPLASMOSE : ",'T',0,'L',1);
+					
+				$this->SetFont('times','',10);
+				$this->Cell(13,6,'» IgM :','T',0,'L',1);
+					
+			
+				$resultatToxoIGM = 'Positif';
+				if($resultats[56]['toxoplasmose_igm'] == 'Negatif'){ $resultatToxoIGM = 'Négatif'; }
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultatToxoIGM,'T',0,'L',1);
+					
+				if($resultats[56]['toxoplasmose_igm_titre']){
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'Titre :','T',0,'L',1);
+						
+					$this->SetFont('times','B',11);
+					$this->Cell(25,6,number_format($resultats[56]['toxoplasmose_igm_titre'], 0, ',', ' ').' UI/ml','T',0,'L',1);
+				}else{
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'','T',0,'L',1);
+						
+					$this->SetFont('times','B',11);
+					$this->Cell(25,6,'','T',0,'L',1);
+				}
+					
+				
+				$this->SetFont('times','',10);
+				$this->Cell(13,6,'» IgG :','T',0,'L',1);
+				
+				$resultatToxoIGG = 'Positif';
+				if($resultats[56]['toxoplasmose_igg'] == 'Negatif'){ $resultatToxoIGG = 'Négatif'; }
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultatToxoIGG,'T',0,'L',1);
+				
+				if($resultats[56]['toxoplasmose_igg_titre']){
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'Titre :','T',0,'L',1);
+					
+					$this->SetFont('times','B',11);
+					$this->Cell(25,6,number_format($resultats[56]['toxoplasmose_igg_titre'], 0, ',', ' ').' UI/ml','T',0,'L',1);
+				}
+				
+				$this->SetFont('times','I',7);
+				$this->Cell(9,6,'','T',1,'L',1);
+				
+				
+				/** Commentaire --- Commentaire --- Commentaire**/
+				/** Commentaire --- Commentaire --- Commentaire**/
+				$commentaireToxo = $resultats[56]['toxoplasmose_commentaire'];
+				if($commentaireToxo){
+					$this->Cell(15,6,'','B',0,'L',1);
+						
+					$this->SetFont('timesbi','U',10);
+					$this->Cell(25,6,'Commentaire :','B',0,'R',1);
+						
+					$this->SetFont('times','B',11);
+					$this->MultiCell(145,6,iconv ('UTF-8' , 'windows-1252', $commentaireToxo),'B','J',1);
+				
+				}
+					
+			}
+			
+			
+			//RUBEOLE --- RUBEOLE --- RUBEOLE --- RUBEOLE --- RUBEOLE --- RUBEOLE
+			if(in_array(57, $idAnalysesSerologie)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','T',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(35,6,"RUBEOLE : ",'T',0,'L',1);
+					
+				$this->SetFont('times','',10);
+				$this->Cell(13,6,'» IgM :','T',0,'L',1);
+					
+					
+				$resultatToxoIGM = 'Positif';
+				if($resultats[57]['rubeole_igm'] == 'Negatif'){ $resultatToxoIGM = 'Négatif'; }
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultatToxoIGM,'T',0,'L',1);
+					
+				if($resultats[57]['rubeole_igm_titre']){
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'Titre :','T',0,'L',1);
+			
+					$this->SetFont('times','B',11);
+					$this->Cell(25,6,number_format($resultats[57]['rubeole_igm_titre'], 0, ',', ' ').' UI/ml','T',0,'L',1);
+				}else{
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'','T',0,'L',1);
+			
+					$this->SetFont('times','B',11);
+					$this->Cell(25,6,'','T',0,'L',1);
+				}
+					
+			
+				$this->SetFont('times','',10);
+				$this->Cell(13,6,'» IgG :','T',0,'L',1);
+			
+				$resultatToxoIGG = 'Positif';
+				if($resultats[57]['rubeole_igg'] == 'Negatif'){ $resultatToxoIGG = 'Négatif'; }
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultatToxoIGG,'T',0,'L',1);
+			
+				if($resultats[57]['rubeole_igg_titre']){
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'Titre :','T',0,'L',1);
+						
+					$this->SetFont('times','B',11);
+					$this->Cell(25,6,number_format($resultats[57]['rubeole_igg_titre'], 0, ',', ' ').' UI/ml','T',0,'L',1);
+				}
+			
+				$this->SetFont('times','I',7);
+				$this->Cell(9,6,'','T',1,'L',1);
+					
+				
+				/** Commentaire --- Commentaire --- Commentaire**/
+				/** Commentaire --- Commentaire --- Commentaire**/
+				$commentaireBubeole = $resultats[57]['rubeole_commentaire'];
+				if($commentaireBubeole){
+					$this->Cell(15,6,'','B',0,'L',1);
+				
+					$this->SetFont('timesbi','U',10);
+					$this->Cell(25,6,'Commentaire :','B',0,'R',1);
+				
+					$this->SetFont('times','B',11);
+					$this->MultiCell(145,6,iconv ('UTF-8' , 'windows-1252', $commentaireBubeole),'B','J',1);
+				}
+				
+			}
+			
+			
+			//SEROLOGIE SYPHILITIQUE BW (RPR/TPHA) --- SEROLOGIE SYPHILITIQUE BW (RPR/TPHA)
+			if(in_array(60, $idAnalysesSerologie)){
+			
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+			
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,'SEROLOGIE SYPHILITIQUE BW : ','BT',0,'L',1);
+			
+				$this->SetFont('times','I',9);
+				$this->Cell(10,6,'RPR : ','BT',0,'R',1);
+			
+				$resultatSerologieSyphilitiqueRpr = 'Positif';
+				if($resultats[60]['serologie_syphilitique_rpr'] == 'Negatif'){ $resultatSerologieSyphilitiqueRpr = 'Négatif'; }
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultatSerologieSyphilitiqueRpr,'BT',0,'L',1);
+			
+				$this->SetFont('times','I',7);
+				$this->Cell(10,6,'','BT',0,'L',1);
+			
+				$this->SetFont('times','I',9);
+				$this->Cell(15,6,'TPHA : ','BT',0,'R',1);
+			
+				$resultatSerologieSyphilitiqueTpha = 'Positif';
+				if($resultats[60]['serologie_syphilitique_tpha'] == 'Negatif'){ $resultatSerologieSyphilitiqueTpha = 'Négatif'; }
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultatSerologieSyphilitiqueTpha,'BT',0,'L',1);
+			
+				if($resultats[60]['serologie_syphilitique_tpha_titre']){
+					$this->SetFont('times','I',9);
+					$this->Cell(25,6,'TITRE : ','BT',0,'R',1);
+					
+					$this->SetFont('times','B',11);
+					$this->Cell(20,6,$resultats[60]['serologie_syphilitique_tpha_titre'],'BT',1,'L',1);
+				}else{
+					$this->SetFont('times','I',7);
+					$this->Cell(45,6,'','BT',1,'L',1);
+				}
+			
+			}
+			
+			
+			//ASLO --- ASLO --- ASLO --- ASLO --- ASLO --- ASLO --- ASLO --- ASLO	
+			if(in_array(60, $idAnalysesSerologie)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,'ASLO : ','BT',0,'L',1);
+					
+				$this->SetFont('times','I',9);
+				$this->Cell(10,6,'','BT',0,'R',1);
+					
+				$resultatAslo = 'Positif';
+				if($resultats[61]['aslo'] == 'Negatif'){ $resultatAslo = 'Négatif'; }
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultatAslo,'BT',0,'L',1);
+					
+				if($resultats[61]['titre']){
+					$this->SetFont('times','I',9);
+					$this->Cell(25,6,'TITRE : ','BT',0,'R',1);
+						
+					$this->SetFont('times','B',11);
+					$this->Cell(35,6,$resultats[61]['titre'].' UI/ml','BT',0,'L',1);
+				}else{
+					$this->SetFont('times','I',7);
+					$this->Cell(45,6,'','BT',0,'L',1);
+				}
+				
+				$this->SetFont('times','I',8);
+				$this->Cell(30,6,'( < 200 UI/mL )','BT',1,'L',1);
+				
+					
+			}
+			
+			
+			// Ag HbS --- Ag HbS --- Ag HbS --- Ag HbS --- Ag HbS --- Ag HbS ---
+			if(in_array(63, $idAnalysesSerologie)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+					
+				$this->Ln(0.5);
+					
+				if(in_array(63, $idAnalysesSerologie)){
+					$this->SetFont('zap','',11.3);
+					$this->Cell(5,6,' +','BT',0,'C',1);
+					$this->SetFont('times','',9);
+					$this->Cell(32,6,'ANTIGENE HbS : ','BT',0,'L',1);
+			
+					$valeurAgHbS = 'Positif';
+					if($resultats[63]['ag_hbs'] == 'Negatif'){ $valeurAgHbS = 'Négatif'; }
+					$this->SetFont('times','B',11);
+					$this->Cell(24,6,$valeurAgHbS,'BT',0,'R',1);
+			
+					$this->SetFont('times','I',8);
+					$this->Cell(31,6,'( Qualitatif )','BT',0,'R',1);
+						
+					/** Séparateur --- Séparateur --- Séparateur **/
+					$this->Cell(1,6,' ','',0,'L',1);
+				}
+					
+				/*
+				 if(in_array(19, $idAnalysesHemostase)){
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(42,6,'FACTEUR 9 : ','BT',0,'L',1);
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(18,6,$resultats[19]['facteur_9'].'  ','BT',0,'R',1);
+			
+				$this->SetFont('times','I',8);
+				$this->Cell(27,6,'','BT',0,'R',1);
+				}
+				*/
+				$this->Cell(92,6,'','BT',0,'R',1);
+				//Aller à la ligne
+				$this->Cell(0,6,'','',1);
+			}
+			
+			
+			
+			//WIDAL --- WIDAL --- WIDAL--- WIDAL --- WIDAL --- WIDAL--- WIDAL ---
+			if(in_array(62, $idAnalysesSerologie)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','T',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(25,6,"WIDAL : ",'T',0,'L',1);
+					
+				/*
+				 * Typhi --- Typhi --- Typhi --- Typhi
+				 */
+				///**** Typhi TO ************************************************************
+				///**** Typhi TO ************************************************************
+				$this->SetFont('times','',10);
+				$this->Cell(28,6,'» Typhi TO :','T',0,'L',1);
+			
+				$resultatTyphiTO  = 'Positif';
+				if($resultats[62]['widal_to'] == 'Negatif'){ $resultatTyphiTO = 'Négatif'; }
+
+				$this->SetFont('times','B',11);
+				$this->Cell(18,6,$resultatTyphiTO,'T',0,'L',1);
+				
+			    if($resultats[62]['widal_titre_to']){
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'Titre :','T',0,'L',1);
+			
+					$this->SetFont('times','B',11);
+					$this->Cell(18,6,number_format($resultats[62]['widal_titre_to'], 0, ',', ' ').' ','T',0,'L',1);
+				}else{
+					$this->SetFont('times','B',11);
+					$this->Cell(28,6,'','T',0,'L',1);
+				}
+					
+				///**** FIN Typhi TO ************************************************************
+				///**** FIN Typhi TO ************************************************************
+						
+				
+				///**** Typhi TH ************************************************************
+				///**** Typhi TH ************************************************************
+				$this->SetFont('times','',10);
+				$this->Cell(26,6,'» Typhi TH :','T',0,'L',1);
+			
+			    $resultatTyphiTH  = 'Positif';
+			    if($resultats[62]['widal_th'] == 'Negatif'){ $resultatTyphiTH = 'Négatif'; }
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultatTyphiTH,'T',0,'L',1);
+			
+			    if($resultats[62]['widal_titre_th']){
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'Titre :','T',0,'L',1);
+						
+					$this->SetFont('times','B',11);
+					$this->Cell(25,6,number_format($resultats[62]['widal_titre_th'], 0, ',', ' ').' ','T',1,'L',1);
+				}else{
+					$this->SetFont('times','B',11);
+					$this->Cell(35,6,'','T',1,'L',1);
+				}
+			
+				///**** FIN Typhi TH ************************************************************
+				///**** FIN Typhi TH ************************************************************
+					
+				/*
+				 * FIN Typhi --- FIN Typhi --- FIN Typhi --- FIN Typhi
+				*/
+				
+				
+				
+				/*
+				 * Paratyphi AO&AH --- Paratyphi AO&AH --- Paratyphi AO&AH --- Paratyphi AO&AH
+				*/
+				$this->Cell(30,6,'','',0,'L',1);
+				///**** Paratyphi AO ************************************************************
+				///**** Paratyphi AO ************************************************************
+				$this->SetFont('times','',10);
+				$this->Cell(28,6,'» Paratyphi AO :','',0,'L',1);
+					
+				$resultatParatyphiAO  = 'Positif';
+				if($resultats[62]['widal_ao'] == 'Negatif'){ $resultatParatyphiAO = 'Négatif'; }
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(18,6,$resultatParatyphiAO,'',0,'L',1);
+				
+				if($resultats[62]['widal_titre_ao']){
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'Titre :','',0,'L',1);
+						
+					$this->SetFont('times','B',11);
+					$this->Cell(18,6,number_format($resultats[62]['widal_titre_ao'], 0, ',', ' ').' ','',0,'L',1);
+				}else{
+					$this->SetFont('times','B',11);
+					$this->Cell(28,6,'','',0,'L',1);
+				}
+					
+				///**** FIN Paratyphi AO ************************************************************
+				///**** FIN Paratyphi TO ************************************************************
+				
+				
+				///**** Paratyphi AH ************************************************************
+				///**** Paratyphi AH ************************************************************
+				$this->SetFont('times','',10);
+				$this->Cell(26,6,'» Paratyphi AH :','',0,'L',1);
+					
+				$resultatParatyphiAH  = 'Positif';
+				if($resultats[62]['widal_ah'] == 'Negatif'){ $resultatParatyphiAH = 'Négatif'; }
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultatParatyphiAH,'',0,'L',1);
+					
+				if($resultats[62]['widal_titre_ah']){
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'Titre :','',0,'L',1);
+				
+					$this->SetFont('times','B',11);
+					$this->Cell(25,6,number_format($resultats[62]['widal_titre_ah'], 0, ',', ' ').' ','',1,'L',1);
+				}else{
+					$this->SetFont('times','B',11);
+					$this->Cell(35,6,'','',1,'L',1);
+				}
+					
+				///**** FIN Paratyphi AH ************************************************************
+				///**** FIN Paratyphi AH ************************************************************
+					
+				/*
+				 * FIN Paratyphi AO&AH --- FIN Paratyphi AO&AH --- FIN Paratyphi AO&AH --- FIN Paratyphi AO&AH
+				*/
+				
+				
+				
+				/*
+				 * Paratyphi BO&BH --- Paratyphi BO&BH --- Paratyphi BO&BH --- Paratyphi BO&BH
+				*/
+				$this->Cell(30,6,'','',0,'L',1);
+				///**** Paratyphi BO ************************************************************
+				///**** Paratyphi BO ************************************************************
+				$this->SetFont('times','',10);
+				$this->Cell(28,6,'» Paratyphi BO :','',0,'L',1);
+					
+				$resultatParatyphiBO  = 'Positif';
+				if($resultats[62]['widal_bo'] == 'Negatif'){ $resultatParatyphiBO = 'Négatif'; }
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(18,6,$resultatParatyphiBO,'',0,'L',1);
+				
+				if($resultats[62]['widal_titre_bo']){
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'Titre :','',0,'L',1);
+				
+					$this->SetFont('times','B',11);
+					$this->Cell(18,6,number_format($resultats[62]['widal_titre_bo'], 0, ',', ' ').' ','',0,'L',1);
+				}else{
+					$this->SetFont('times','B',11);
+					$this->Cell(28,6,'','',0,'L',1);
+				}
+					
+				///**** FIN Paratyphi BO ************************************************************
+				///**** FIN Paratyphi BO ************************************************************
+				
+				
+				///**** Paratyphi BH ************************************************************
+				///**** Paratyphi BH ************************************************************
+				$this->SetFont('times','',10);
+				$this->Cell(26,6,'» Paratyphi BH :','',0,'L',1);
+					
+				$resultatParatyphiBH  = 'Positif';
+				if($resultats[62]['widal_bh'] == 'Negatif'){ $resultatParatyphiBH = 'Négatif'; }
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultatParatyphiBH,'',0,'L',1);
+					
+				if($resultats[62]['widal_titre_bh']){
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'Titre :','',0,'L',1);
+				
+					$this->SetFont('times','B',11);
+					$this->Cell(25,6,number_format($resultats[62]['widal_titre_bh'], 0, ',', ' ').' ','',1,'L',1);
+				}else{
+					$this->SetFont('times','B',11);
+					$this->Cell(35,6,'','',1,'L',1);
+				}
+					
+				///**** FIN Paratyphi BH ************************************************************
+				///**** FIN Paratyphi BH ************************************************************
+					
+				/*
+				 * FIN Paratyphi BO&BH --- FIN Paratyphi BO&BH --- FIN Paratyphi BO&BH --- FIN Paratyphi BO&BH
+				*/
+				
+				
+				/*
+				 * Paratyphi CO&CH --- Paratyphi CO&CH --- Paratyphi CO&CH --- Paratyphi CO&CH
+				*/
+				$this->Cell(30,6,'','B',0,'L',1);
+				///**** Paratyphi CO ************************************************************
+				///**** Paratyphi CO ************************************************************
+				$this->SetFont('times','',10);
+				$this->Cell(28,6,'» Paratyphi CO :','B',0,'L',1);
+					
+				$resultatParatyphiCO  = 'Positif';
+				if($resultats[62]['widal_co'] == 'Negatif'){ $resultatParatyphiCO = 'Négatif'; }
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(18,6,$resultatParatyphiCO,'B',0,'L',1);
+				
+				if($resultats[62]['widal_titre_co']){
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'Titre :','B',0,'L',1);
+				
+					$this->SetFont('times','B',11);
+					$this->Cell(18,6,number_format($resultats[62]['widal_titre_co'], 0, ',', ' ').' ','B',0,'L',1);
+				}else{
+					$this->SetFont('times','B',11);
+					$this->Cell(28,6,'','B',0,'L',1);
+				}
+					
+				///**** FIN Paratyphi CO ************************************************************
+				///**** FIN Paratyphi CO ************************************************************
+				
+				
+				///**** Paratyphi CH ************************************************************
+				///**** Paratyphi CH ************************************************************
+				$this->SetFont('times','',10);
+				$this->Cell(26,6,'» Paratyphi CH :','B',0,'L',1);
+					
+				$resultatParatyphiCH  = 'Positif';
+				if($resultats[62]['widal_ch'] == 'Negatif'){ $resultatParatyphiCH = 'Négatif'; }
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultatParatyphiCH,'B',0,'L',1);
+					
+				if($resultats[62]['widal_titre_ch']){
+					$this->SetFont('times','I',9);
+					$this->Cell(10,6,'Titre :','B',0,'L',1);
+				
+					$this->SetFont('times','B',11);
+					$this->Cell(25,6,number_format($resultats[62]['widal_titre_ch'], 0, ',', ' ').' ','B',1,'L',1);
+				}else{
+					$this->SetFont('times','B',11);
+					$this->Cell(35,6,'','B',1,'L',1);
+				}
+					
+				///**** FIN Paratyphi CH ************************************************************
+				///**** FIN Paratyphi CH ************************************************************
+					
+				/*
+				 * FIN Paratyphi CO&CH --- FIN Paratyphi CO&CH --- FIN Paratyphi CO&CH --- FIN Paratyphi CO&CH
+				*/
+				
+				
+			}
+			
+			
+			// Beta HCG --- Beta HCG --- Beta HCG --- Beta HCG --- Beta HCG --- Beta HCG ---
+			if(in_array(51, $idAnalysesSerologie)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+					
+				$this->Ln(0.5);
+					
+				if(in_array(51, $idAnalysesSerologie)){
+					$this->SetFont('zap','',11.3);
+					$this->Cell(5,6,' +','BT',0,'C',1);
+					$this->SetFont('times','',9);
+					$this->Cell(52,6,'BETA HCG PLASMATIQUE : ','BT',0,'L',1);
+						
+					$valeurBetaHcg = 'Positif';
+					if($resultats[51]['beta_hcg_plasmatique'] == 'Negatif'){ $valeurBetaHcg = 'Négatif'; }
+					$this->SetFont('times','B',11);
+					$this->Cell(24,6,$valeurBetaHcg,'BT',0,'R',1);
+						
+					$this->SetFont('times','I',8);
+					$this->Cell(31,6,'( Qualitatif )','BT',0,'R',1);
+			
+					/** Séparateur --- Séparateur --- Séparateur **/
+					$this->Cell(1,6,' ','',0,'L',1);
+				}
+					
+				/*
+				 if(in_array(19, $idAnalysesHemostase)){
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(42,6,'FACTEUR 9 : ','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(18,6,$resultats[19]['facteur_9'].'  ','BT',0,'R',1);
+					
+				$this->SetFont('times','I',8);
+				$this->Cell(27,6,'','BT',0,'R',1);
+				}
+				*/
+				$this->Cell(72,6,'','BT',0,'R',1);
+				//Aller à la ligne
+				$this->Cell(0,6,'','',1);
+			}
+			
+		}
+		
+		
+		
+		/**
+		 * GESTION DES RESULTATS DANS
+		 * --- BILAN HEPATIQUE --- BILAN HEPATIQUE --- BILAN HEPATIQUE 
+		 */
+		
+		$idAnalysesBilanHepatique = $this->getAnalysesBilanHepatique();
+		if($idAnalysesBilanHepatique){
+			$indice = 0;
+			$this->Ln(1);
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			$this->SetDrawColor(220,220,220);
+		
+			$this->SetFont('times','I',9);
+			$this->Cell(35,7,'','',0,'L',0);
+			$this->SetFont('times','U',10);
+			$this->Cell(115,7,'BILAN HEPATIQUE','',0,'C',0);
+			$this->Cell(35,7,'','',1,'C',0);
+			$this->Ln(1);
+		
+			//TRANSAMINASES --- TRANSAMINASES --- TRANSAMINASES --- TRANSAMINASES
+			if(in_array(37, $idAnalysesBilanHepatique)){
+		
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+		
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(40,6,'TRANSAMINASES : ','BT',0,'L',1);
+				
+				$this->SetFont('times','I',9);
+				$this->Cell(20,6,'TGO/ASAT : ','BT',0,'R',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultats[37][1]['tgo_asat'].' u/l','BT',0,'L',1);
+				
+				$this->SetFont('times','I',7);
+				$this->Cell(30,6,'( H < 35 , F < 31 )','BT',0,'L',1);
+				
+				$this->SetFont('times','I',9);
+				$this->Cell(20,6,'TGP/ALAT : ','BT',0,'R',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultats[37][2]['tgp_alat'].' u/l','BT',0,'L',1);
+				
+				$this->SetFont('times','I',7);
+				$this->Cell(30,6,'( H < 45 , F < 34 )','BT',1,'L',1);
+		
+			}
+			
+			//PHOSPHATAGE ALCALINE (PAL) --- PHOSPHATAGE ALCALINE (PAL) --- PHOSPHATAGE ALCALINE (PAL)
+			if(in_array(38, $idAnalysesBilanHepatique)){
+			
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+			
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,'PHOSPHATAGE ALCALINE (PAL) : ','BT',0,'L',1);
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultats[38]['valeur'].' u/l','BT',0,'L',1);
+			
+				$this->SetFont('times','I',7);
+				$this->Cell(30,6,'( H: 40 à 129 ; F: 35 à 104 )','BT',0,'L',1);
+			
+				$this->SetFont('times','I',9);
+				$this->Cell(20,6,'','BT',0,'R',1);
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,'','BT',0,'L',1);
+			
+				$this->SetFont('times','I',7);
+				$this->Cell(30,6,'','BT',1,'L',1);
+			
+			}
+			
+			//GAMA GT = YGT --- GAMA GT = YGT --- GAMA GT = YGT --- GAMA GT = YGT
+			if(in_array(39, $idAnalysesBilanHepatique)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,'GAMA GT = YGT : ','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,$resultats[39]['valeur'].' UI/l','BT',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(30,6,'( H: 11 à 50 ; F: 7 à 32 )','BT',0,'L',1);
+					
+				$this->SetFont('times','I',9);
+				$this->Cell(20,6,'','BT',0,'R',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,'','BT',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(30,6,'','BT',1,'L',1);
+					
+			}
+			
+			//BILIRUBINE TOTALE & DIRECTE --- BILIRUBINE TOTALE & DIRECTE
+			if(in_array(42, $idAnalysesBilanHepatique)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249);}
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(55,6,'BILIRUBINE TOTALE & DIRECTE : ','T',0,'L',1);
+					
+				/*** Bilirubine totale ***/
+				$this->SetFont('times','I',10);
+				$this->Cell(33,5,'» Bilirubine totale :','T',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,5,$resultats[42]['bilirubine_totale'].' mg/l','T',0,'R',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(20,5,'( < 10 )','T',0,'C',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(30,5,number_format($resultats[42]['bilirubine_totale_auto'], 2, ',', ' ').' umol/l','T',0,'R',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(22,5,'( < 17,105 )','T',1,'C',1);
+				
+				/*** Bilirubine directe ***/
+				$this->Cell(60,5,'','',0,'L',1);
+				
+				$this->SetFont('times','I',10);
+				$this->Cell(33,5,'» Bilirubine directe :','',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,5,$resultats[42]['bilirubine_directe'].' mg/l','',0,'R',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(20,5,'( < 4 )','T',0,'C',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(30,5,number_format($resultats[42]['bilirubine_directe_auto'], 2, ',', ' ').' umol/l','',0,'R',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(22,5,'( < 6,8420 )','',1,'C',1);
+					
+				/*** Bilirubine indecte ***/
+				$this->Cell(60,5,'','B',0,'L',1);
+				
+				$this->SetFont('times','I',10);
+				$this->Cell(33,5,'» Bilirubine indirecte :','B',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,5,$resultats[42]['bilirubine_indirecte'].' mg/l','B',0,'R',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(20,5,'( < 6 )','T',0,'C',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(30,5,number_format($resultats[42]['bilirubine_indirecte_auto'], 2, ',', ' ').' umol/l','B',0,'R',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(22,5,'( < 10,26 )','B',1,'C',1);
+				
+			}
+		
+		}
+		
+		
+		
+		
+		/**
+		 * GESTION DES RESULTATS DANS
+		 * --- BILAN RENAL --- BILAN RENAL --- BILAN RENAL
+		 */
+		
+		$idAnalysesBilanRenal = $this->getAnalysesBilanRenal();
+		if($idAnalysesBilanRenal){
+			$indice = 0;
+			$this->Ln(1);
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			$this->SetDrawColor(220,220,220);
+		
+			$this->SetFont('times','I',9);
+			$this->Cell(35,7,'','',0,'L',0);
+			$this->SetFont('times','U',10);
+			$this->Cell(115,7,'BILAN RENAL','',0,'C',0);
+			$this->Cell(35,7,'','',1,'C',0);
+			$this->Ln(1);
+		
+			//CREATININEMIE --- CREATININEMIE --- CREATININEMIE --- CREATININEMIE ---
+			if(in_array(22, $idAnalysesBilanRenal)){
+		
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); } 
+		
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(40,6,'CREATININEMIE : ','BT',0,'L',1);
+		
+				$this->SetFont('times','B',11);
+				$this->Cell(25,6,$resultats[22]['creatininemie'].' mg/l','BT',0,'L',1);
+		
+				$this->SetFont('times','I',7);
+				$this->Cell(40,6,'( H= 7 à 13 | F= 6 à 11 )','BT',0,'L',1);
+		
+				
+				if($resultats[22]['creatininemie']){
+					$valeurEnUmol = number_format($resultats[22]['creatininemie']*8.84, 2, ',', ' ');
+					$this->SetFont('times','B',11);
+					$this->Cell(35,6,$valeurEnUmol.' mmol/l','BT',0,'L',1);
+					
+					$this->SetFont('times','I',7);
+					$this->Cell(40,6,'( H= 61,8 à 114,9 | F= 53,0 à 97,2 )','BT',1,'L',1);
+				}else{
+					$this->SetFont('times','B',11);
+					$this->Cell(35,6,'','BT',0,'R',1);
+					
+					$this->SetFont('times','I',7);
+					$this->Cell(40,6,'','BT',1,'L',1);					
+				}
+		
+			}
+			
+			//AZOTEMIE = UREE --- AZOTEMIE = UREE --- AZOTEMIE = UREE --- AZOTEMIE = UREE
+			if(in_array(23, $idAnalysesBilanRenal)){
+			
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+			
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(40,6,'AZOTEMIE = UREE : ','BT',0,'L',1);
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(25,6,number_format($resultats[23]['valeur'],2, ',', ' ').' mg/l','BT',0,'L',1);
+			
+				$this->SetFont('times','I',7);
+				$this->Cell(40,6,'( 0,15 à 0,45 )','BT',0,'L',1);
+
+				$this->SetFont('times','B',11);
+				$this->Cell(35,6,number_format($resultats[23]['valeur_mmol'],2, ',', ' ').' mmol/l','BT',0,'L',1);
+
+				$this->SetFont('times','I',7);
+				$this->Cell(40,6,'( 2,49 à 7,49 )','BT',1,'L',1);
+			
+			}
+			
+			//URICEMIE = ACIDE URIQUE --- URICEMIE = ACIDE URIQUE --- URICEMIE = ACIDE URIQUE
+			if(in_array(24, $idAnalysesBilanRenal)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(45,6,'URICEMIE = ACIDE URIQUE : ','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(25,6,$resultats[24]['acide_urique'].' mg/l','BT',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(30,6,'( H= 35 à 72 ; F= 26 à 60 )','BT',0,'L',1);
+					
+				$this->SetFont('times','I',9);
+				$this->Cell(7,6,'','BT',0,'R',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(33,6,number_format($resultats[24]['acide_urique_umol'],2, ',', ' ').' mmol/l','BT',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(40,6,'(  H= 208 à 428, F= 154 à 356  )','BT',1,'L',1);
+					
+			}
+			
+			//ALBUMINEMIE --- ALBUMINEMIE --- ALBUMINEMIE --- ALBUMINEMIE
+			if(in_array(46, $idAnalysesBilanRenal)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(55,6,'ALBUMINEMIE : ','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(25,6,$resultats[46]['albuminemie'].' g/l','BT',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(30,6,'( 35 - 53 )','BT',0,'L',1);
+					
+				$this->SetFont('times','I',9);
+				$this->Cell(20,6,'','BT',0,'R',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,'','BT',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(30,6,'','BT',1,'L',1);
+					
+			}
+			
+			
+			//ALBUMINE URINAIRE (BANDELETTES) --- ALBUMINE URINAIRE (BANDELETTES) --- 
+			if(in_array(47, $idAnalysesBilanRenal)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(65,6,'ALBUMINE URINAIRE (BANDELETTES) : ','T',0,'L',1);
+					
+				/*Albumine --- Albumine --- Albumine*/
+				$this->SetFont('times','I',10);
+				$this->Cell(20,6,'» Albumine : ','T',0,'R',1);
+				
+				$albumine = 'Positif';
+				if($resultats[47]['albumine_urinaire'] == 'negatif'){ $albumine = 'Négatif'; }
+				$this->SetFont('times','B',11);
+				$this->Cell(15,6,$albumine,'T',0,'L',1);
+					
+				if($resultats[47]['albumine_urinaire_degres']){
+					$this->SetFont('zap','',11.5);
+					$this->Cell(8,6,' à','T',0,'L',1);
+					
+					$this->SetFont('times','B',12);
+					$this->Cell(15,6,$resultats[47]['albumine_urinaire_degres'],'T',0,'L',1);
+				}else{
+					$this->Cell(23,6,'','T',0,'L',1);
+				}
+				
+				/*Sucre --- Sucre --- Sucre -- Sucre --- Sucre*/
+				$this->SetFont('times','I',10);
+				$this->Cell(20,6,'» Sucre : ','T',0,'R',1);
+				
+				$sucre_urinaire = 'Positif';
+				if($resultats[47]['sucre_urinaire'] == 'negatif'){ $sucre_urinaire = 'Négatif'; }
+				$this->SetFont('times','B',11);
+				$this->Cell(15,6,$sucre_urinaire,'T',0,'L',1);
+					
+				if($resultats[47]['sucre_urinaire_degres']){
+					$this->SetFont('zap','',11.5);
+					$this->Cell(8,6,' à','T',0,'L',1);
+					
+					$this->SetFont('times','B',12);
+					$this->Cell(14,6,$resultats[47]['sucre_urinaire_degres'],'T',1,'L',1);
+				}else{
+					$this->Cell(22,6,'','T',1,'L',1);
+				}
+				
+				
+				/*Corps cétonique --- Corps cétonique --- Corps cétonique*/
+				$this->Cell(70,6,'','B',0,'L',1); 
+				
+				$this->SetFont('times','I',10);
+				$this->Cell(20,6,'» Corps cétonique : ','B',0,'R',1);
+				
+				$albumine = 'Positif';
+				if($resultats[47]['corps_cetonique_urinaire'] == 'negatif'){ $albumine = 'Négatif'; }
+				$this->SetFont('times','B',11);
+				$this->Cell(15,6,$albumine,'B',0,'L',1);
+					
+				if($resultats[47]['corps_cetonique_urinaire_degres']){
+					$this->SetFont('zap','',11.5);
+					$this->Cell(8,6,' à','B',0,'L',1);
+						
+					$this->SetFont('times','B',12);
+					$this->Cell(15,6,$resultats[47]['corps_cetonique_urinaire_degres'],'B',0,'L',1);
+				}else{
+					$this->Cell(23,6,'','B',0,'L',1);
+				}
+				
+				$this->Cell(57,6,'','B',1,'L',1);
+				
+			}
+			
+			
+			
+		}
+		
+		
+		/**
+		 * GESTION DES RESULTATS DANS
+		 * --- METABOLISME GLUCIDIQUE --- METABOLISME GLUCIDIQUE --- METABOLISME GLUCIDIQUE
+		 */
+		
+		$idAnalysesMetabolismeGlucidique = $this->getAnalysesMetabolismeGlucidique();
+		if($idAnalysesMetabolismeGlucidique){
+			$indice = 0;
+			$this->Ln(1);
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			$this->SetDrawColor(220,220,220);
+		
+			$this->SetFont('times','I',9);
+			$this->Cell(35,7,'','',0,'L',0);
+			$this->SetFont('times','U',10);
+			$this->Cell(115,7,'METABOLISME GLUCIDIQUE','',0,'C',0);
+			$this->Cell(35,7,'','',1,'C',0);
+			$this->Ln(1);
+		
+			//GLYCEMIE --- GLYCEMIE --- GLYCEMIE --- GLYCEMIE --- GLYCEMIE
+			if(in_array(21, $idAnalysesMetabolismeGlucidique)){
+		
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+		
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(40,6,'GLYCEMIE : ','BT',0,'L',1);
+		
+				$this->SetFont('times','B',11);
+				$this->Cell(25,6,number_format($resultats[21]['glycemie_1'], 2, ',', ' ').' g/l','BT',0,'L',1);
+		
+				$this->SetFont('times','I',7);
+				$this->Cell(40,6,'( H= 0,7 à 1,10 )','BT',0,'L',1);
+
+				$this->SetFont('times','B',11);
+				$this->Cell(35,6,number_format($resultats[21]['glycemie_2'], 2, ',', ' ').' mmol/l','BT',0,'L',1);
+
+				$this->SetFont('times','I',7);
+				$this->Cell(40,6,'( 4,1 à 5,9 )','BT',1,'L',1);
+		
+			}
+			
+			
+			//HEMOGLOBINE GLYQUEE HbA1c  --- HEMOGLOBINE GLYQUEE HbA1c --- HEMOGLOBINE GLYQUEE HbA1c
+			if(in_array(43, $idAnalysesMetabolismeGlucidique)){
+			
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+			
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(55,6,'HEMOGLOBINE GLYQUEE HbA1c : ','BT',0,'L',1);
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(18,6,number_format($resultats[43]['hemoglobine_glyquee_hbac'], 1, ',', ' ').' %','BT',0,'L',1);
+			
+				$this->SetFont('times','I',7);
+				$this->Cell(40,6,'( HbA1C DCCT N: 4,27 - 6,07 )','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(35,6,number_format($resultats[43]['hemoglobine_glyquee_hbac_mmol'], 0, ',', ' ').' mmol/mol','BT',0,'L',1);
+						
+				$this->SetFont('times','I',7);
+				$this->Cell(32,6,'( HbA1C IFCC N: 23 - 42 )','BT',1,'L',1);
+			
+			}
+		
+		}
+		
+		/**
+		 * GESTION DES RESULTATS DANS
+		 * --- BILAN LIPIDIQUE --- BILAN LIPIDIQUE --- BILAN LIPIDIQUE --- BILAN LIPIDIQUE
+		 */
+		
+		$idAnalysesBilanLipidique = $this->getAnalysesBilanLipidique();
+		if($idAnalysesBilanLipidique){
+			$indice = 0;
+			$this->Ln(1);
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			$this->SetDrawColor(220,220,220);
+		
+			$this->SetFont('times','I',9);
+			$this->Cell(35,7,'','',0,'L',0);
+			$this->SetFont('times','U',10);
+			$this->Cell(115,7,'BILAN LIPIDIQUE','',0,'C',0);
+			$this->Cell(35,7,'','',1,'C',0);
+			$this->Ln(1);
+		
+			//CHOLESTEROL TOTAL  --- CHOLESTEROL TOTAL --- CHOLESTEROL TOTAL
+			if(in_array(25, $idAnalysesBilanLipidique)){
+		
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+		
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,10,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(40,10,'CHOLESTEROL TOTAL : ','BT',0,'L',1);
+		
+				$this->SetFont('times','B',11);
+				$this->Cell(25,10,number_format($resultats[25]['cholesterol_total_1'], 2, ',', ' ').' g/l','BT',0,'L',1);
+		
+				$this->Cell(5,10,'','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(25,10,number_format($resultats[25]['cholesterol_total_2'], 2, ',', ' ').' mmol/l','BT',0,'L',1);
+		
+				$this->Cell(5,10,'','BT',0,'L',1);
+				
+				$this->SetFont('times','I',7.2);
+				$this->Cell(80,10,'','BT',0,'L',1);
+				
+				$x = $this->GetX(); $y = $this->GetY();
+				$this->Text($x-80, $y+3, 'Moins de 30 ans <1, 80 (4, 7 mmol/l) - Plus de 30 ans < 2, 00 (< 5, 2mmol/l)');
+				$this->Text($x-80, $y+6, 'Interprétation clinique : suspect supérieur à 2, 20 (5, 7 mmol/l)');
+				$this->Text($x-80, $y+9, 'Risque élevé supérieur à 2, 60 (6, 7 mmol/l)');
+				
+				//Allez à la ligne suivante
+				$this->Cell(0,10,'','',1,'L',1);
+			}
+		
+			//CHOLESTEROL HDL  --- CHOLESTEROL HDL --- CHOLESTEROL HDL --- CHOLESTEROL HDL
+			if(in_array(27, $idAnalysesBilanLipidique)){
+			
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+			
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,10,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(40,10,'CHOLESTEROL HDL : ','BT',0,'L',1);
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(25,10,number_format($resultats[27]['cholesterol_HDL_1'], 2, ',', ' ').' g/l','BT',0,'L',1);
+			
+				$this->Cell(5,10,'','BT',0,'L',1);
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(25,10,number_format($resultats[27]['cholesterol_HDL_2'], 2, ',', ' ').' mmol/l','BT',0,'L',1);
+			
+				$this->Cell(5,10,'','BT',0,'L',1);
+			
+				$this->SetFont('times','I',7.2);
+				$this->Cell(80,10,'','BT',0,'L',1);
+			
+				$x = $this->GetX(); $y = $this->GetY();
+				$this->Text($x-80, $y+3, '< 0, 35 ( < 0, 9 mmol/l) facteur de risque pour coronaropathies');
+				$this->Text($x-80, $y+6, '> 0, 60 ( > 1, 5 mmol/l) risque réduit pour coronaropathies');
+				$this->Text($x-80, $y+9, '');
+			
+				//Allez à la ligne suivante
+				$this->Cell(0,10,'','',1,'L',1);
+			}
+			
+			//CHOLESTEROL LDL  --- CHOLESTEROL LDL --- CHOLESTEROL LDL --- CHOLESTEROL LDL
+			if(in_array(28, $idAnalysesBilanLipidique)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,10,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(40,10,'CHOLESTEROL LDL : ','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(25,10,number_format($resultats[28]['cholesterol_LDL_1'], 2, ',', ' ').' g/l','BT',0,'L',1);
+					
+				$this->Cell(5,10,'','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(25,10,number_format($resultats[28]['cholesterol_LDL_2'], 2, ',', ' ').' mmol/l','BT',0,'L',1);
+					
+				$this->Cell(5,10,'','BT',0,'L',1);
+					
+				$this->SetFont('times','I',7.2);
+				$this->Cell(80,10,'','BT',0,'L',1);
+					
+				$x = $this->GetX(); $y = $this->GetY();
+				$this->Text($x-80, $y+3, 'H < 0,50 (< 1,3 mmol/l); F: < 0,63 (< 1,6 mmol/l) risque réduit pour cor.. ');
+				$this->Text($x-80, $y+6, 'H > 1,72 (> 4,5 mmol/l); F: > 1,67 (4,3 mmol/l) risque accru pour cor.. ');
+				$this->Text($x-80, $y+9, '(cor = coronaropathies) ');
+					
+				//Allez à la ligne suivante
+				$this->Cell(0,10,'','',1,'L',1);
+			}
+			
+			//--- TRIGLYCERIDES  --- TRIGLYCERIDES --- TRIGLYCERIDES --- TRIGLYCERIDES
+			if(in_array(26, $idAnalysesBilanLipidique)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,10,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(40,10,'TRIGLYCERIDES : ','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(25,10,number_format($resultats[26]['triglycerides_1'], 2, ',', ' ').' g/l','BT',0,'L',1);
+					
+				$this->Cell(5,10,'','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(25,10,number_format($resultats[26]['triglycerides_2'], 2, ',', ' ').' mmol/l','BT',0,'L',1);
+					
+				$this->Cell(5,10,'','BT',0,'L',1);
+					
+				$this->Cell(80,10,'','BT',0,'L',1);
+					
+				$x = $this->GetX(); $y = $this->GetY();
+				$this->SetFont('timesbi','U',7.2);
+				$this->Text($x-80, $y+3, 'Suspect supérieur à 1,50 (1,71 mmol/l)');
+				$this->SetFont('times','I',7.2);
+				$this->Text($x-80, $y+6, 'Interprétation clinique pour risque d\'athéroclérose');
+				$this->Text($x-80, $y+9, 'Risque accru supérieur à 2,00 (2,28 mmol/l)');
+					
+				//Allez à la ligne suivante
+				$this->Cell(0,10,'','',1,'L',1);
+			}
+			
+			//--- RAPPORT CHOLESTEROL TOTAL & HDL  --- RAPPORT CHOLESTEROL TOTAL & HDL
+			if(in_array(25, $idAnalysesBilanLipidique) && in_array(27, $idAnalysesBilanLipidique)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,10,' *','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(40,10,'Rapport: CHOLT/HDL : ','BT',0,'L',1);
+					
+				$rapportCHOL = $resultats[25]['cholesterol_total_1']/$resultats[27]['cholesterol_HDL_1'];
+				$this->SetFont('times','B',11);
+				$this->Cell(25,10,number_format($rapportCHOL, 2, ',', ' ').' ','BT',0,'L',1);
+					
+				$this->Cell(5,10,'','BT',0,'L',1);
+					
+				$this->SetFont('times','I',9);
+				$this->Cell(25,10,'( N: < 4,5 )','BT',0,'L',1);
+					
+				$this->Cell(5,10,'','BT',0,'L',1);
+					
+				//Affichage de la conclusion du rapport
+				if($rapportCHOL >= 4.5 && $rapportCHOL <= 5){
+					$conclusion_rapport_chol_hdl = "Risque d'athérogène faible";
+				}else if($rapportCHOL > 5 && $rapportCHOL <= 6.5){
+					$conclusion_rapport_chol_hdl = "Risque d'athérogène modéré";
+				}else if($rapportCHOL > 6.5){
+					$conclusion_rapport_chol_hdl = "Risque d'athérogène élevé";
+				}else{
+					$conclusion_rapport_chol_hdl = "RAS";
+				}
+				
+				$this->SetFont('timesi','U',10);
+				$this->Cell(20,10,'Conclusion :','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(60,10,$conclusion_rapport_chol_hdl,'BT',1,'L',1);
+				
+			}
+			
+			//LIPIDES TOTAUX  --- LIPIDES TOTAUX --- LIPIDES TOTAUX --- LIPIDES TOTAUX
+			if(in_array(30, $idAnalysesBilanLipidique)){
+			
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+			
+				$this->Ln(1);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(40,6,'LIPIDES TOTAUX : ','BT',0,'L',1);
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(25,6,number_format($resultats[30]['lipides_totaux'], 1, ',', ' ').' g/l','BT',0,'L',1);
+			
+				$this->SetFont('times','I',7);
+				$this->Cell(5,6,'','BT',0,'L',1);
+				
+				$this->SetFont('times','I',8);
+				$this->Cell(35,6,'( 4 - 7 g/l )','BT',0,'L',1);
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(35,6,'','BT',0,'L',1);
+			
+				$this->SetFont('times','I',7);
+				$this->Cell(40,6,'','BT',1,'L',1);
+			
+			}
+			
+		}
+		
+		
+		/**
+		 * GESTION DES RESULTATS DANS
+		 * --- METABOLISME DU FER --- METABOLISME DU FER --- METABOLISME DU FER --- METABOLISME DU FER
+		 */
+		
+		$idAnalysesMetabolismeDuFer = $this->getAnalysesMetabolismeFer();
+		if($idAnalysesMetabolismeDuFer){
+			$indice = 0;
+			$this->Ln(1);
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			$this->SetDrawColor(220,220,220);
+		
+			$this->SetFont('times','I',9);
+			$this->Cell(35,7,'','',0,'L',0);
+			$this->SetFont('times','U',10);
+			$this->Cell(115,7,'METABOLISME DU FER','',0,'C',0);
+			$this->Cell(35,7,'','',1,'C',0);
+			$this->Ln(1);
+		
+			//FER SERIQUE  --- FER SERIQUE --- FER SERIQUE --- FER SERIQUE 
+		    if(in_array(40, $idAnalysesMetabolismeDuFer)){
+		
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); } 
+		
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(40,6,'FER SERIQUE : ','BT',0,'L',1);
+		
+				$this->SetFont('times','B',11);
+				$this->Cell(25,6,number_format($resultats[40]['valeur_ug'], 1, ',', ' ').' ug/dl','BT',0,'L',1);
+		
+				$this->SetFont('times','I',7);
+				$this->Cell(40,6,'( H: 64,8 à 175 - F: 50,3 à 170 )','BT',0,'L',1);
+
+				$this->SetFont('times','B',11);
+				$this->Cell(35,6,number_format($resultats[40]['valeur_umol'], 1, ',', ' ').' umol/l','BT',0,'L',1);
+
+				$this->SetFont('times','I',7);
+				$this->Cell(40,6,'( H: 11,6 à 31,3 - F: 9,0 à 30,4 )','BT',1,'L',1);
+			}
+			
+			//FERRITININE  --- FERRITININE --- FERRITININE --- FERRITININE
+			if(in_array(41, $idAnalysesMetabolismeDuFer)){
+			
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+			
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(40,6,'FERRITININE : ','BT',0,'L',1);
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(25,6,number_format($resultats[41]['ferritinine'], 0, ',', ' ').' ng/ml','BT',0,'L',1);
+			
+				$this->SetFont('times','I',7);
+				$this->Cell(30,6,'( hommes: 70 - 435 ng/ml )','BT',0,'L',1);
+			
+				$this->SetFont('times','I',7);
+				$this->Cell(40,6,'( Femmes cycliques: 10 - 160 ng/ml )','BT',0,'L',1);
+			
+				$this->SetFont('times','I',7);
+				$this->Cell(45,6,'( Femmes ménopausées: 25 - 280 ng/ml )','BT',1,'L',1);
+			}
+			
+			
+		}
+		
+		
+		/**
+		 * GESTION DES RESULTATS DANS
+		 * --- BILAN D'ELECTROLYTE --- BILAN D'ELECTROLYTE --- BILAN D'ELECTROLYTE 
+		 */
+		
+		$idAnalysesBilanElectrolyte = $this->getAnalysesBilanElectrolyte();
+		if($idAnalysesBilanElectrolyte){
+			$indice = 0;
+			$this->Ln(1);
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			$this->SetDrawColor(220,220,220);
+		
+			$this->SetFont('times','I',9);
+			$this->Cell(35,7,'','',0,'L',0);
+			$this->SetFont('times','U',10);
+			$this->Cell(115,7,"BILAN D'ELECTROLYTE",'',0,'C',0);
+			$this->Cell(35,7,'','',1,'C',0);
+			$this->Ln(1);
+		
+			//IONOGRAMME  --- IONOGRAMME --- IONOGRAMME --- IONOGRAMME
+			if(in_array(31, $idAnalysesBilanElectrolyte)){
+		
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+		
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(30,6,'IONOGRAMME : ','BT',0,'L',1);
+		
+				$this->SetFont('times','I',10);
+				$this->Cell(20,6,'Natrémie :','BT',0,'R',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(30,6,number_format($resultats[31]['sodium_sanguin'], 0, ',', ' ').' mmol/l','BT',0,'L',1);
+		
+				$this->SetFont('times','I',10);
+				$this->Cell(20,6,'Kaliémie :','BT',0,'R',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(30,6,number_format($resultats[31]['potassium_sanguin'], 1, ',', ' ').' mmol/l','BT',0,'L',1);
+				
+				$this->SetFont('times','I',10);
+				$this->Cell(20,6,'Chlorémie :','BT',0,'R',1);
+		
+				$this->SetFont('times','B',11);
+				$this->Cell(30,6,number_format($resultats[31]['chlore_sanguin'], 0, ',', ' ').' mmol/l','BT',1,'L',1);
+			}
+			
+			//CALCEMIE  --- CALCEMIE --- CALCEMIE --- CALCEMIE --- CALCEMIE
+			if(in_array(32, $idAnalysesBilanElectrolyte)){
+			
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+			
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(35,6,'CALCEMIE : ','BT',0,'L',1);
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,number_format($resultats[32]['calcemie'], 0, ',', ' ').' mg/l','BT',0,'L',1);
+			
+				$this->SetFont('times','I',7);
+				$this->Cell(47,6,'( Adultes: 86 à 103  ;  Enfants: 100 à 120 )','BT',0,'L',1);
+				
+				$this->Cell(2,6,'','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(28,6,number_format($resultats[32]['calcemie_mmol'], 2, ',', ' ').' mmol/l','BT',0,'L',1);
+			
+				$this->SetFont('times','I',7);
+				$this->Cell(48,6,'( Adultes: 2,14 à 2,56 ; Enfants: 2,49 à 2,98 )','BT',1,'L',1);
+			}
+			
+			//MAGNESEMIE  --- MAGNESEMIE --- MAGNESEMIE --- MAGNESEMIE --- MAGNESEMIE
+			if(in_array(33, $idAnalysesBilanElectrolyte)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(35,6,'MAGNESEMIE : ','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(40,6,number_format($resultats[33]['magnesemie'], 0, ',', ' ').' mg/l','BT',0,'L',1);
+					
+				$this->SetFont('times','I',8);
+				$this->Cell(50,6,'( 17 à 24 )','BT',0,'L',1);
+			
+				$this->SetFont('times','B',11);
+				$this->Cell(25,6,'','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(30,6,'','BT',1,'L',1);
+			}
+			
+			//PHOSPHOREMIE  --- PHOSPHOREMIE --- PHOSPHOREMIE --- PHOSPHOREMIE --- PHOSPHOREMIE
+			if(in_array(34, $idAnalysesBilanElectrolyte)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(35,6,'PHOSPHOREMIE : ','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,number_format($resultats[34]['phosphoremie'], 0, ',', ' ').' mg/l','BT',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(47,6,'( Adultes: 25 à 50  ;  Enfants: 40 à 70 )','BT',0,'L',1);
+				
+				$this->Cell(2,6,'','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(28,6,number_format($resultats[34]['phosphoremie_mmol'], 2, ',', ' ').' mmol/l','BT',0,'L',1);
+					
+				$this->SetFont('times','I',6.5);
+				$this->Cell(48,6,'( Adultes: 8,07 à 16,15 ; Enfants: 12,92 à 22,61 )','BT',1,'L',1);
+					
+			}
+				
+			
+				
+		}
+		
+		
+		/**
+		 * GESTION DES RESULTATS DANS
+		 * --- TYPAGE DE L'HEMOGLOBINE --- TYPAGE DE L'HEMOGLOBINE --- TYPAGE DE L'HEMOGLOBINE
+		 */
+		
+		$idAnalysesTypageHemoProteine = $this->getAnalysesTypageHemoProteine();
+		if($idAnalysesTypageHemoProteine){
+			$indice = 0;
+			$this->Ln(1);
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			$this->SetDrawColor(220,220,220);
+		
+			$this->SetFont('times','I',9);
+			$this->Cell(35,7,'','',0,'L',0);
+			$this->SetFont('times','U',10);
+			$this->Cell(115,7,"TYPAGE DE L'HEMOGLOBINE",'',0,'C',0);
+			$this->Cell(35,7,'','',1,'C',0);
+			$this->Ln(1);
+		
+			//ELECTROPHORESE DE L'HEMOGLOBINE  --- ELECTROPHORESE DE L'HEMOGLOBINE --- 
+			if(in_array(44, $idAnalysesTypageHemoProteine)){
+		
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+		
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(65,6,"ELECTROPHORESE DE L'HEMOGLOBINE : ",'BT',0,'L',1);
+		
+				$this->SetFont('times','I',11);
+				$this->Cell(112,6,'','T',0,'L',1);
+				
+				$x = $this->GetX()-112;
+				for($i = 0 ; $i < count($resultats[44])&& $i < 4 ; $i++){
+				
+					$y = $this->GetY();
+					$libElecHem = $resultats[44][$i]['libelle'];
+					if(strlen($libElecHem) == 4){
+						//Dernier caractère pour indice
+						$dernierCaractere = $libElecHem{strlen($libElecHem)-1};
+						$premierePartie = $libElecHem[0].$libElecHem[1].$libElecHem[2];
+					}else{
+						$dernierCaractere = null;
+						$premierePartie = $libElecHem;
+					}
+
+					$this->SetFont('times','I',11);
+					$this->Text($x, $y+4, $premierePartie);
+					$this->Text($x+7, $y+5, $dernierCaractere);
+					$this->Text($x+8.5, $y+4, ' : ');
+					
+					$this->SetFont('times','B',11);
+					$this->Text($x+10.5, $y+4, '  '.$resultats[44][$i]['valeur']);
+					$x+=25;
+					
+					
+				}
+				
+				$this->Cell(3,6,'','T',1,'L',1);
+				
+				$this->SetFont('timesi','U',11);
+				$this->Cell(70,6,"Conclusion :",'B',0,'R',1);
+				
+				$this->SetFont('timesb','',11);
+				$this->Cell(115,6,iconv ('UTF-8' , 'windows-1252', $resultats[44][0]['conclusion']),'B',1,'L',1);
+				
+			}
+			
+		}
+		
+		
+		/**
+		 * GESTION DES RESULTATS DANS
+		 * --- METABOLISME PROTIDIQUE --- METABOLISME PROTIDIQUE --- METABOLISME PROTIDIQUE
+		 */
+		
+		$idAnalysesMetabolismeProtidique = $this->getAnalysesMetabolismeProtidique();
+		if($idAnalysesMetabolismeProtidique){
+			$indice = 0;
+			$this->Ln(1);
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			//AFFICHAGE DE L'EN TETE DU TEXTE
+			$this->SetDrawColor(220,220,220);
+		
+			$this->SetFont('times','I',9);
+			$this->Cell(35,7,'','',0,'L',0);
+			$this->SetFont('times','U',10);
+			$this->Cell(115,7,"METABOLISME PROTIDIQUE",'',0,'C',0);
+			$this->Cell(35,7,'','',1,'C',0);
+			$this->Ln(1);
+		
+			//ELECTROPHORESE DES PROTEINES  --- ELECTROPHORESE DES PROTEINES ---
+			if(in_array(45, $idAnalysesMetabolismeProtidique)){
+		
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+		
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,"ELECTROPHORESE DES PROTEINES : ",'BT',0,'L',1);
+		
+				/** Protéine totale --- Protéine totale --- Protéine totale**/
+				/** Protéine totale --- Protéine totale --- Protéine totale**/
+				$this->SetFont('times','I',11);
+				$this->Cell(33,6,'» Protéine totale : ','BT',0,'L',1);
+		
+				$this->SetFont('times','B',11);
+				$this->Cell(30,6,number_format($resultats[45]['proteine_totale'], 1, ',', ' ').' g/l','BT',0,'L',1);
+				
+				$this->SetFont('times','I',7);
+				$this->Cell(57,6,'( N: Adultes: 66 à 83 ; Nouveaux nés: 52 à 91 )','BT',1,'L',1);
+				
+				
+				/** Albumine --- Albumine --- Albumine --- Albumine */
+				/** Albumine --- Albumine --- Albumine --- Albumine */
+				$this->Cell(15,6,'','BT',0,'L',1);
+				
+				$this->SetFont('times','I',11);
+				$this->Cell(23,6,'» Albumine : ','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,number_format($resultats[45]['albumine'], 1, ',', ' ').' %','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,number_format($resultats[45]['albumine_abs'], 1, ',', ' ').' g/l','BT',0,'L',1);
+				
+				$this->SetFont('times','I',7);
+				$this->Cell(22,6,'( 40,2 - 47,6 )','BT',0,'L',1);
+				
+				/** Partie vide --- Partie vide --- Partie vide **/
+				$this->SetFont('times','I',11);
+				$this->Cell(23,6,' ','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,'','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,'','BT',0,'L',1);
+				
+				$this->SetFont('times','I',7);
+				$this->Cell(22,6,'','BT',1,'L',1);
+				
+				
+				/** Alpha 1 --- Alpha 1 --- Alpha 1**/
+				/** Alpha 1 --- Alpha 1 --- Alpha 1**/
+				$this->Cell(15,6,'','BT',0,'L',1);
+				
+				$this->SetFont('times','I',11);
+				$this->Cell(23,6,'» Alpha 1 : ','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,number_format($resultats[45]['alpha_1'], 1, ',', ' ').' %','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,number_format($resultats[45]['alpha_1_abs'], 1, ',', ' ').' g/l','BT',0,'L',1);
+				
+				$this->SetFont('times','I',7);
+				$this->Cell(22,6,'( 2,1 - 3,5 )','BT',0,'L',1);
+				
+				/** Alpha 2 --- Alpha 2 --- Alpha 2**/
+				/** Alpha 2 --- Alpha 2 --- Alpha 2**/
+				
+				$this->SetFont('times','I',11);
+				$this->Cell(23,6,'» Alpha 2 : ','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,number_format($resultats[45]['alpha_2'], 1, ',', ' ').' %','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,number_format($resultats[45]['alpha_2_abs'], 1, ',', ' ').' g/l','BT',0,'L',1);
+				
+				$this->SetFont('times','I',7);
+				$this->Cell(22,6,'( 5,1 - 8,5 )','BT',1,'L',1);
+
+				
+				/** Beta 1 --- Beta 1 --- Beta 1**/
+				/** Beta 1 --- Beta 1 --- Beta 1**/
+				$this->Cell(15,6,'','BT',0,'L',1);
+				
+				$this->SetFont('times','I',11);
+				$this->Cell(23,6,'» Beta 1 : ','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,number_format($resultats[45]['beta_1'], 1, ',', ' ').' %','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,number_format($resultats[45]['beta_1_abs'], 1, ',', ' ').' g/l','BT',0,'L',1);
+				
+				$this->SetFont('times','I',7);
+				$this->Cell(22,6,'( 3,4 - 5,2 )','BT',0,'L',1);
+				
+				/** Beta 2 --- Beta 2 --- Beta 2**/
+				/** Beta 2 --- Beta 2 --- Beta 2**/
+				
+				$this->SetFont('times','I',11);
+				$this->Cell(23,6,'» Beta 2 : ','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,number_format($resultats[45]['beta_2'], 1, ',', ' ').' %','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,number_format($resultats[45]['beta_2_abs'], 1, ',', ' ').' g/l','BT',0,'L',1);
+				
+				$this->SetFont('times','I',7);
+				$this->Cell(22,6,'( 2,3 - 4,7 )','BT',1,'L',1);
+				
+				
+				/** Gamma --- Gamma --- Gamma**/
+				/** Gamma --- Gamma --- Gamma**/
+				$this->Cell(15,6,'','BT',0,'L',1);
+				
+				$this->SetFont('times','I',11);
+				$this->Cell(23,6,'» Gamma : ','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,number_format($resultats[45]['gamma'], 1, ',', ' ').' %','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,number_format($resultats[45]['gamma_abs'], 1, ',', ' ').' g/l','BT',0,'L',1);
+				
+				$this->SetFont('times','I',7);
+				$this->Cell(22,6,'( 8,0 - 13,5 )','BT',0,'L',1);
+				
+				/** Espace vide --- Espace vide --- Espace vide **/
+				/** Espace vide --- Espace vide --- Espace vide **/
+				
+				$this->SetFont('times','I',11);
+				$this->Cell(43,6,'','BT',0,'L',1);
+				
+				$this->SetFont('times','B',11);
+				$this->Cell(20,6,'','BT',0,'L',1);
+				
+				$this->SetFont('times','I',7);
+				$this->Cell(22,6,'','BT',1,'L',1);
+				
+				
+				
+				/** Conclusion --- Conclusion --- Conclusion**/
+				/** Conclusion --- Conclusion --- Conclusion**/
+				$this->Cell(15,6,'','BT',0,'L',1);
+				
+				$this->SetFont('timesbi','U',10);
+				$this->Cell(25,6,'Commentaire :','BT',0,'R',1);
+				
+				$this->SetFont('times','B',11);
+				$this->MultiCell(145,6,iconv ('UTF-8' , 'windows-1252', $resultats[45]['commentaire']),'BT','J',1);
+				
+			}
+			
+
+			//PROTEINES TOTAL (PROTIDEMIE) --- PROTEINES TOTAL (PROTIDEMIE) --- PROTEINES TOTAL (PROTIDEMIE)
+			if(in_array(48, $idAnalysesMetabolismeProtidique)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,'PROTEINES TOTAL (PROTIDEMIE) : ','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(25,6,$resultats[48]['protidemie'].'  g/l','BT',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(50,6,'( N: Adultes: 66 à 83 ; Nouveaux nés: 52 à 91 )','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(45,6,'','BT',1,'L',1);
+					
+			}
+			
+			
+			//PROTEINURIE DES 24H --- PROTEINURIE DES 24H --- PROTEINURIE DES 24H
+			if(in_array(49, $idAnalysesMetabolismeProtidique)){
+					
+				if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+					
+				$this->Ln(0.5);
+				$this->SetFont('zap','',11.3);
+				$this->Cell(5,6,' +','BT',0,'C',1);
+				$this->SetFont('times','',9);
+				$this->Cell(60,6,'PROTEINURIE DES 24H : ','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(25,6,number_format($resultats[49]['proteinurie'], 2, ',', ' ').'  g/24H','BT',0,'L',1);
+					
+				$this->SetFont('times','I',7);
+				$this->Cell(50,6,'( < 0,15 g/24H )','BT',0,'L',1);
+					
+				$this->SetFont('times','B',11);
+				$this->Cell(45,6,'','BT',1,'L',1);
+					
+			}
+			
+			
+			
+			
+		}
+		
+		
+	
+	}
+	
+	
+	
+	
+	
+	function AfficherResultatsTypageHemoglobine(){
+		$controle = new DateHelper();
+		$this->AddFont('symb','','symbol.php');
+		$this->AddFont('zap','','zapfdingbats.php');
+		$this->AddFont('timesb','','timesb.php');
+		$this->AddFont('timesi','','timesi.php');
+		$this->AddFont('times','','times.php');
+		
+		$resultats = $this->getResultatsAnalysesDemandees();
+		$listeAnalysesDemandees = $this->getAnalysesDemandees();
+		$infosAnalyseDemande = array();
+		
+		for($i = 0 ; $i < count($listeAnalysesDemandees) ; $i++){
+			$idanalyse = $listeAnalysesDemandees[$i]['idanalyse'];
+		
+			if($idanalyse == 68){
+				$analyses[$idanalyse]            = $listeAnalysesDemandees[$i]['Designation'];
+				$idAnalyses[$idanalyse]          = $idanalyse;
+				$typesAnalyses[$idanalyse]       = $listeAnalysesDemandees[$i]['Libelle'];
+				$infosAnalyseDemande[$idanalyse] = $listeAnalysesDemandees[$i];
+			}
+		}
+		
+		//Date de prelèvement
+		$datePrelevement = $infosAnalyseDemande[68]['DateHeurePrelevement'];
+		
+		//Affichage des infos sur le biologiste et le technicien
+		$dateEnregistrement  =  $controle->convertDateTime($infosAnalyseDemande[68]['DateEnregistrementResultat']);
+		$prenomNomTechnicien = $infosAnalyseDemande[68]['Prenom'].' '.$infosAnalyseDemande[68]['Nom'];
+		$prenomNomBiologiste = $infosAnalyseDemande[68]['PrenomValidateur'].' '.$infosAnalyseDemande[68]['NomValidateur'];
+		
+		$this->SetFont('times','',8);
+		//$this->Cell(45,-1,'Enregistré le : '.$dateEnregistrement,'',0,'L',0);
+		$this->Cell(45,-1,'Prélèvement effectué le : '.$datePrelevement,'',0,'L',0);
+		
+		//$this->Cell(90,-1,'par : '.$prenomNomTechnicien.' ; validé par : '.$prenomNomBiologiste,'',1,'L',0);
+		$this->Cell(90,-1,'','',1,'L',0);
+		
+		$this->Ln(5);
+		
+		//AFFICHAGE DE L'EN TETE DU TEXTE
+		//AFFICHAGE DE L'EN TETE DU TEXTE
+		$this->SetFillColor(249,249,249);
+		$this->SetDrawColor(220,220,220);
+		
+		$this->SetFont('times','I',9);
+		$this->Cell(35,7,'Dépistage néonatal','',0,'L',0);
+		$this->SetFont('times','U',10);
+		$this->Cell(115,7,"TYPAGE DE L'HEMOGLOBINE",'',0,'C',0);
+		$this->Cell(35,7,'','',1,'C',0);
+		
+		$this->Ln(3);
+		
+		//matériel utilisé --- matériel utilisé --- matériel utilisé
+		$this->SetFont('zap','',11.3);
+		$this->Cell(4,6,' ^','BT',0,'C',1);
+		$this->SetFont('times','',11);
+		$this->Cell(181,6,'Type de matériel utilisé : '.$resultats[68]['type_materiel'],'BT',1,'L',1);
+		
+		$this->Ln(4);
+		
+		$indice = 0;
+		$this->Ln(1);
+		
+		$idAnalysesTypageHemoglobine = $this->getAnalysesTypageHemoglobine();
+		if(in_array(68, $idAnalysesTypageHemoglobine)){
+		
+			if(($indice++%2) == 0){ $this->SetFillColor(225,225,225); }else{ $this->SetFillColor(249,249,249); }
+		
+			$this->Ln(0.5);
+			$this->SetFont('zap','',11.3);
+			$this->Cell(45,6,' +','BT',0,'R',1);
+			$this->SetFont('times','',9);
+			$this->Cell(35,6,'PROFIL DU PATIENT : ','BT',0,'L',1);
+		
+			$this->SetFont('times','B',11);
+			$this->Cell(60,6,iconv ('UTF-8' , 'windows-1252', $resultats[68]['Designation_stat'].''),'BT',0,'L',1);
+		
+			$this->SetFont('symb','',11);
+			$this->Cell(45,6,'','BT',0,'L',1);
+		
+		}
+		
+		
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+}
+
+?>

--- a/public/css/consultation/modifierConsultation.css
+++ b/public/css/consultation/modifierConsultation.css
@@ -520,13 +520,26 @@ width: 190px; /* la largeur du champ input*/
 	margin-bottom: 15px;
 }
 
-.titreZoneInfosEFStyle, .titreZoneInfosEAFStyle
+.titreZoneInfosEFStyle, .titreZoneInfosEAFStyle, .titreZoneInfosStylePop
 {
 	width: 100%; 
 	font-family: Tempus Sans ITC;  
 	color: green; 
 	font-size: 20px; 
 	padding-bottom: 2px;
+}
+
+
+.contenuZoneInfosStylePopDemExam th:hover
+{
+	background-color: #fdfdfd;
+}
+
+
+.contenuZoneInfosStylePopDemExam
+{
+	height: 45px;
+	margin-bottom: 15px;
 }
 
 

--- a/public/css/monstyle.css
+++ b/public/css/monstyle.css
@@ -1768,7 +1768,7 @@ width: 50px; /* la largeur du champ input*/
 
 }
 
-#transfert select
+#transfert select, #transfert input[type="text"]
 {
 	background-image: none;
 
@@ -1959,8 +1959,20 @@ top: 3px;
 z-index: 7;
 }
 
+#transfert input[type="text"]
+{
 
-#transfert input[type="text"], #transfert textarea 
+display: block;
+
+height: 30px; /*la hauteur du champ input*/
+
+width: 90%;/*395px; /* la largeur du champ input*/
+	
+padding-left: 5px;
+
+}
+
+#transfert textarea 
 {
 
 display: block;
@@ -2686,7 +2698,7 @@ width: 80%;
 /************************************ STYLE Rendez-vous ****************************************/
 /************************************ STYLE Rendez-vous ****************************************/
 
-#rendezvous input[type="text"], #rendezvous select
+#rendezvous input[type="text"], #rendezvous select, #rendezvous input[type="date"]
 
 { /*le input ou le textarea*/
 /*background-color: #fffffa; /*la couleur du champ*/
@@ -3000,7 +3012,7 @@ z-index: 7;
 }
 
 
-#rendezvous input[type="text"]
+#rendezvous input[type="text"], #rendezvous input[type="date"]
 {
 
 display: block;
@@ -3022,7 +3034,7 @@ width: 90%/*395px; /* la largeur du champ input*/
 
 }
 
-#rendezvous input[type="text"]:focus, #rendezvous textarea:focus, #rendezvous select:focus
+#rendezvous input[type="text"]:focus, #rendezvous textarea:focus, #rendezvous select:focus, #rendezvous input[type="text"]:focus
 {
 
    text-indent: 0pt;

--- a/public/js/biologiste/jsListeResultatsAnalyses.js
+++ b/public/js/biologiste/jsListeResultatsAnalyses.js
@@ -1412,8 +1412,8 @@
     
     var tabInfosCulotUrinaire = new Array();
     tabInfosCulotUrinaire[0] = "";
-    tabInfosCulotUrinaire[1] = "";
-    tabInfosCulotUrinaire[2] = "";
+    tabInfosCulotUrinaire[1] = '<input disabled type="text" name="culot_urinaire_val_1" id="culot_urinaire_val_1" style="width:95%; text-align: left; padding-left: 3px;">';
+    tabInfosCulotUrinaire[2] = '<input disabled type="text" name="culot_urinaire_val_2" id="culot_urinaire_val_2" style="width:95%; text-align: left; padding-left: 3px;">';
     tabInfosCulotUrinaire[3] = '<select disabled name="culot_urinaire_val_3" id="culot_urinaire_val_3" style="width: 95%;"> ' +
     		                   "  <option></option> " +
     		                   "  <option value=1>Oxalate de potassium | calcium</option> " +

--- a/public/js/consultation/ajoutDemandesAnalyses.js
+++ b/public/js/consultation/ajoutDemandesAnalyses.js
@@ -233,6 +233,10 @@ function chargementModificationAnalyses (listeAnalysesDemandees, tabListeAnalyse
 			$("#SelectAnalyse_"+(index+1)+" option[value='0,"+idanalyse+"']").attr('selected','selected');
 
 			$("#tarifActe"+(index+1)).val('___');
+			
+			//AutoAjout des champs de saisi des résultats
+			ajoutAutomatiqueChampsResultats(index+1);
+			
 		}else{
 			var idanalyse = listeAnalysesDemandees[index]['idanalyse'];
 			//SÃ©lection des analyses sur les listes 

--- a/public/js/consultation/consultation/consulter.js
+++ b/public/js/consultation/consultation/consulter.js
@@ -204,7 +204,10 @@ function initialisationScript(agePatient) {
 		
 	});
 	
-	
+	$( "#terminerCons" ).click(function(){
+		affichageDesExamensDemandes();
+		envoyerLesDonneesASauvegarder();
+	});
 	
 	//APPLICATION DE LA POSOLOGIE AUTOMATIQUEMENT POUR LE CAS "DOULEUR"
 	//APPLICATION DE LA POSOLOGIE AUTOMATIQUEMENT POUR LE CAS "DOULEUR"
@@ -1066,9 +1069,49 @@ function supprimeDroiteChampResultatExamenRadio($id, nbListeActe, elsup){
 	
 }
 
+var tabDonneesMotifsDesExamensRadioSauvegardees = new Array();
+var tabDonneesMotifsDesExamensSauvegardees = new Array();
 
+function envoyerLesDonneesASauvegarder(){
+	
+	var scriptDonneesMotifsExamensAEnvoyer = "";
+	var indExamRadio = 0;
+	var indExamBio = 0;
+	
+	for(var i=0 ; i<indicesIdExamensRadio ; i++){
+		if(tabDonneesIdExamensRadioSauvegardees[i][0] == 0){
+			
+			var idExamenRadio = tabDonneesIdExamensRadioSauvegardees[i][2];
+			var motifExamenRadio = tabDonneesMotifsDesExamensRadioSauvegardees[idExamenRadio];
+			scriptDonneesMotifsExamensAEnvoyer +='<input type="hidden" name="idExamenRadio_'+(indExamRadio)+'" value="'+idExamenRadio+'" >';
+			scriptDonneesMotifsExamensAEnvoyer +='<input type="hidden" name="motifExamenRadio_'+(indExamRadio++)+'" value="'+motifExamenRadio+'" >';
+			
+		}
+	}
+	
+	for(var i=0 ; i<indicesIdExamens ; i++){
+			
+		var idExamenBio = tabDonneesIdExamensSauvegardees[i];
+		var motifExamenBio = tabDonneesMotifsDesExamensSauvegardees[idExamenBio];
+		scriptDonneesMotifsExamensAEnvoyer +='<input type="hidden" name="idExamenBio_'+(indExamBio)+'" value="'+idExamenBio+'" >';
+		scriptDonneesMotifsExamensAEnvoyer +='<input type="hidden" name="motifExamenBio_'+(indExamBio++)+'" value="'+motifExamenBio+'" >';
+			
+	}
+	
+	scriptDonneesMotifsExamensAEnvoyer +="<input type='hidden' name='nbExamenRadio' value='"+indExamRadio+"' >";
+	scriptDonneesMotifsExamensAEnvoyer +="<input type='hidden' name='nbExamenBio' value='"+indExamBio+"' >";
+	
+	$("#sauverLesInfosDesExamensRadioBioSaisisPopup").html(scriptDonneesMotifsExamensAEnvoyer);
+}
+
+var tabDonneesIdExamensRadioSauvegardees = new Array();
+var tabDonneesIdExamensSauvegardees = new Array();
+
+var indicesIdExamensRadio = 0;
+var indicesIdExamens = 0;
 
 function effectuerDesDemandesExamens(){
+	
 	$( "#imprimerDesDemandesExamensAvecSaisiMotifs" ).dialog({
 	    resizable: false,
 	    height:675,
@@ -1079,25 +1122,32 @@ function effectuerDesDemandesExamens(){
 	    	
 	        "Terminer": function() {
 	        	
+	        	envoyerLesDonneesASauvegarder();
 	        	$( this ).dialog( "close" );
+	        	
 	        },
 	        
 	   }
-	  });
+	});
 	
-	affichageDesExamensDemandes();
-	
-	$("#imprimerDesDemandesExamensAvecSaisiMotifs").dialog('open');
+	var tabIdExamens = affichageDesExamensDemandes();
+	if(tabIdExamens.length > 0){
+		$("#imprimerDesDemandesExamensAvecSaisiMotifs").dialog('open');
+	}else{
+		alert("Aucun examen n'est selectionne");
+	}
 }
 
 
 function affichageDesExamensDemandes(){
 	
+	indicesIdExamensRadio = 0;
+	indicesIdExamens = 0;
 	var tabTypesExamens = [];
 	var tabExamens = [];
 	var tabIdExamens = [];
 	var tabTarifsExamens =[];
-	for(var i = 1, j = 1; i <= nbListeActe(); i++ ){
+	for( var i = 1, j = 1; i <= nbListeActe(); i++ ){
 		if($('.type_analyse_name_'+i).val()) {
 			tabTypesExamens[j] = $('.type_analyse_name_'+i+' option:selected').text(); 
 			tabExamens[j] = $('.analyse_name_'+i+' option:selected').text(); 
@@ -1107,43 +1157,67 @@ function affichageDesExamensDemandes(){
 		}
 	}
 	
-	
+	$('#contenuimprimerDesDemandesExamensAvecSaisiMotifs table').toggle(false);
 	$('#contenuimprimerDesDemandesExamensAvecSaisiMotifs .contenuExamDemImprime').remove();
 	
 	
 	//*** RECUPERATION DES EXAMENS RADIOLOGIQUES --- RECUPERATION DES EXAMENS RADIOLOGIQUES 
 	//*** RECUPERATION DES EXAMENS RADIOLOGIQUES --- RECUPERATION DES EXAMENS RADIOLOGIQUES 
 	var examenRadioDemandeAajoute = "";
+	var scriptSauvegardeMotifExamenRadio = "";
 	for(var k=1 ; k<tabExamens.length ; k++){
 		var typeExamen = $('.type_analyse_name_'+k+' option:selected').val();
 		if( typeExamen == 6 ){
+			$('#contenuExamRadioDemImprime_0').toggle(true);
+			
 			var baliseMere = $('#codePourAjouterDesExamensDemandesAImprimer');
 			baliseMere.addClass('contenuExamDemImprime_'+k);
 			
 			//Creer les attributs name
-			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen input').attr('name', 'idExamenDem_'+k);
-			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen textarea').attr({'name':'motifExamenDem_'+k, 'id':'motifExamenDem_'+k});
+			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen input').attr('name', 'idExamenRadioDem_'+k);
+			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen textarea').attr({'name':'motifExamenRadioDem_'+k, 'id':'motifExamenRadioDem_'+k});
+			
+			var idExamen = tabIdExamens[k];
 			
 			//Ajouter les valeurs
-			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen input').val(tabIdExamens[k]);
+			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen input').val(idExamen);
 			$('.contenuExamDemImprime_'+k+' .libelleExamenDemandeAImprimer').html(tabExamens[k]);
 			
 			//Creer l'icone pdf pour imprimer un examens precis
 			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen #imageImpressionExamenPopPrecis').html('<img onclick="imprimerUnExamenDemandePop('+k+');" style="float: right; width: 20px; height: 20px; margin-top: 5px; cursor: pointer;" src="../images_icons/pdf.png"  title="Imprimer" >');
 			
+			//Sauvegarder les données saisies dans le champs
+			scriptSauvegardeMotifExamenRadio += "<script>"+
+			       "$('#motifExamenRadioDem_"+k+"').keyup(function(){"+
+				     "tabDonneesMotifsDesExamensRadioSauvegardees["+idExamen+"] = $('#motifExamenRadioDem_"+k+"').val();"+				
+			       "})"+
+			       ".change(function(){"+
+				     "tabDonneesMotifsDesExamensRadioSauvegardees["+idExamen+"] = $('#motifExamenRadioDem_"+k+"').val();"+				
+			       "});"+
+			       "$('#motifExamenRadioDem_"+k+"').val(tabDonneesMotifsDesExamensRadioSauvegardees["+idExamen+"]);"+
+			       "tabDonneesMotifsDesExamensRadioSauvegardees["+idExamen+"] = $('#motifExamenRadioDem_"+k+"').val();"+
+			       "</script>";
+
+			//tabDonneesIdExamensSauvegardees[indicesIdExamens++] = idExamen;
+			tabDonneesIdExamensRadioSauvegardees[indicesIdExamensRadio++] = idExamen;
+			//alert(tabDonneesIdExamensRadioSauvegardees);
+			//============================================
 			examenRadioDemandeAajoute += baliseMere.html();
 		}
 	}
 	//A PLACER APRES LA PREMIERE TABLE
-	$('#contenuExamRadioDemImprime_0').after(examenRadioDemandeAajoute);
+	$('#contenuExamRadioDemImprime_0').after(examenRadioDemandeAajoute+''+scriptSauvegardeMotifExamenRadio);
 
 	
 	//*** RECUPERATION DES EXAMENS BIOLOGIQUES --- RECUPERATION DES EXAMENS BIOLOGIQUES 
 	//*** RECUPERATION DES EXAMENS BIOLOGIQUES --- RECUPERATION DES EXAMENS BIOLOGIQUES 
 	var examenBioDemandeAajoute = "";
+	var scriptSauvegardeMotifExamenBio = "";
 	for(var k=1 ; k<tabExamens.length ; k++){
 		var typeExamen = $('.type_analyse_name_'+k+' option:selected').val();
 		if( typeExamen != 6 ){
+			$('#contenuExamBioDemImprime_0').toggle(true);
+			
 			var baliseMere = $('#codePourAjouterDesExamensDemandesAImprimer');
 			baliseMere.addClass('contenuExamDemImprime_'+k);
 			
@@ -1158,24 +1232,59 @@ function affichageDesExamensDemandes(){
 			//Creer l'icone pdf pour imprimer un examens precis
 			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen #imageImpressionExamenPopPrecis').html('<img onclick="imprimerUnExamenDemandePop('+k+');" style="float: right; width: 20px; height: 20px; margin-top: 5px; cursor: pointer;" src="../images_icons/pdf.png"  title="Imprimer" >');
 			
+
+			//Sauvegarder les données saisies dans le champs
+			scriptSauvegardeMotifExamenBio += "<script>"+
+			       "$('#motifExamenDem_"+k+"').keyup(function(){"+
+				     "tabDonneesMotifsDesExamensSauvegardees["+tabIdExamens[k]+"] = $('#motifExamenDem_"+k+"').val();"+				
+			       "})"+
+			       ".change(function(){"+
+				     "tabDonneesMotifsDesExamensSauvegardees["+tabIdExamens[k]+"] = $('#motifExamenDem_"+k+"').val();"+				
+			       "});"+
+			       "$('#motifExamenDem_"+k+"').val(tabDonneesMotifsDesExamensSauvegardees["+tabIdExamens[k]+"]);"+
+			       "tabDonneesMotifsDesExamensSauvegardees["+tabIdExamens[k]+"] = $('#motifExamenDem_"+k+"').val();"+
+			       "</script>";
+			
+
+			tabDonneesIdExamensSauvegardees[indicesIdExamens++] = tabIdExamens[k];
+			
+			//============================================
 			examenBioDemandeAajoute += baliseMere.html();
 		}
 	}
 	
 	
 	//A PLACER APRES LA PREMIERE TABLE
-	$('#contenuExamBioDemImprime_0').after(examenBioDemandeAajoute);
+	$('#contenuExamBioDemImprime_0').after(examenBioDemandeAajoute+''+scriptSauvegardeMotifExamenBio);
 	
 	
-	
+	return tabIdExamens;
 }
 
 
-function imprimerTousLesExamensDemandesPop(){
+function imprimerTousLesExamensRadioDemandesPop(){
 	
 	var idpatient = $("#idpatient").val();
 	
-	var lienUrl = tabUrl[0]+'public/consultation/impression-examens-demandes';
+	var tabTypesExamens = [];
+	var tabExamens = [];
+	var tabIdExamens = [];
+	var tabMotifExamenDem = [];
+	
+	for(var i = 1, j = 1; i <= nbListeActe(); i++ ){
+		var typeExamen = $('.type_analyse_name_'+i+' option:selected').val();
+		
+		if($('.type_analyse_name_'+i).val() &&  typeExamen == 6 ) {
+			tabTypesExamens[j] = $('.type_analyse_name_'+i+' option:selected').val(); 
+			tabExamens[j] = $('.analyse_name_'+i+' option:selected').text(); 
+			tabIdExamens[j] = $('.analyse_name_'+i+' option:selected').val(); 
+			tabMotifExamenDem[j] = $('#motifExamenRadioDem_'+i).val();
+			j++;
+		}
+	}
+	
+	
+	var lienUrl = tabUrl[0]+'public/consultation/impression-examens-radio-demandes';
 	var formulaireImprimerDemandesAnalyses = document.getElementById("formulaireExamensDemandesPopup");
 	formulaireImprimerDemandesAnalyses.setAttribute("action", lienUrl);
 	formulaireImprimerDemandesAnalyses.setAttribute("method", "POST");
@@ -1189,61 +1298,161 @@ function imprimerTousLesExamensDemandesPop(){
 	champ.setAttribute("value", idpatient);
 	formulaireImprimerDemandesAnalyses.appendChild(champ);
 	
-	
-	/*
-	 
 	var champ2 = document.createElement("input");
 	champ2.setAttribute("type", "hidden");
-	champ2.setAttribute("name", 'idcons');
-	champ2.setAttribute("value", idcons);
+	champ2.setAttribute("name", 'tabTypesExamens');
+	champ2.setAttribute("value", tabTypesExamens);
 	formulaireImprimerDemandesAnalyses.appendChild(champ2);
 	
 	var champ3 = document.createElement("input");
 	champ3.setAttribute("type", "hidden");
-	champ3.setAttribute("name", 'medicamentLibelle');
-	champ3.setAttribute("value", medicamentLibelle);
+	champ3.setAttribute("name", 'tabExamens');
+	champ3.setAttribute("value", tabExamens);
 	formulaireImprimerDemandesAnalyses.appendChild(champ3);
 	
 	var champ4 = document.createElement("input");
 	champ4.setAttribute("type", "hidden");
-	champ4.setAttribute("name", 'formeMedicament');
-	champ4.setAttribute("value", formeMedicament);
+	champ4.setAttribute("name", 'tabIdExamens');
+	champ4.setAttribute("value", tabIdExamens);
 	formulaireImprimerDemandesAnalyses.appendChild(champ4);
 	
 	var champ5 = document.createElement("input");
 	champ5.setAttribute("type", "hidden");
-	champ5.setAttribute("name", 'nbMedicament');
-	champ5.setAttribute("value", nbMedicament);
+	champ5.setAttribute("name", 'tabMotifExamenDem');
+	champ5.setAttribute("value", tabMotifExamenDem);
 	formulaireImprimerDemandesAnalyses.appendChild(champ5);
-	
-	var champ6 = document.createElement("input");
-	champ6.setAttribute("type", "hidden");
-	champ6.setAttribute("name", 'quantiteMedicament');
-	champ6.setAttribute("value", quantiteMedicament);
-	formulaireImprimerDemandesAnalyses.appendChild(champ6);
-	
-	 */
 	
 	$("#imprimerExamensDemandesPopup").trigger('click'); 
 }
 
+function imprimerTousLesExamensBioDemandesPop(){
+	
+	var idpatient = $("#idpatient").val();
+	
+	var tabTypesExamens = [];
+	var tabExamens = [];
+	var tabIdExamens = [];
+	var tabMotifExamenDem = [];
+	
+	for(var i = 1, j = 1; i <= nbListeActe(); i++ ){
+		var typeExamen = $('.type_analyse_name_'+i+' option:selected').val();
+		
+		if( $('.type_analyse_name_'+i).val() &&  typeExamen != 6 ) {
+			tabTypesExamens[j] = $('.type_analyse_name_'+i+' option:selected').val(); 
+			tabExamens[j] = $('.analyse_name_'+i+' option:selected').text(); 
+			tabIdExamens[j] = $('.analyse_name_'+i+' option:selected').val(); 
+			tabMotifExamenDem[j] = $('#motifExamenDem_'+i).val();
+			j++;
+		}
+	}
+	
+	var lienExamenBioUrl = tabUrl[0]+'public/consultation/impression-examens-bio-demandes';
+	var formulaireImprimerDemandesAnalyses = document.getElementById("formulaireExamensBioDemandesPopup");
+	formulaireImprimerDemandesAnalyses.setAttribute("action", lienExamenBioUrl);
+	formulaireImprimerDemandesAnalyses.setAttribute("method", "POST");
+	formulaireImprimerDemandesAnalyses.setAttribute("target", "_blank");
+	
+	// Ajout dynamique de champs dans le formulaire
+	var champ = document.createElement("input");
+	champ.setAttribute("type", "hidden");
+	champ.setAttribute("name", 'idpatient');
+	champ.setAttribute("value", idpatient);
+	formulaireImprimerDemandesAnalyses.appendChild(champ);
+	
+	var champ2 = document.createElement("input");
+	champ2.setAttribute("type", "hidden");
+	champ2.setAttribute("name", 'tabTypesExamens');
+	champ2.setAttribute("value", tabTypesExamens);
+	formulaireImprimerDemandesAnalyses.appendChild(champ2);
+	
+	var champ3 = document.createElement("input");
+	champ3.setAttribute("type", "hidden");
+	champ3.setAttribute("name", 'tabExamens');
+	champ3.setAttribute("value", tabExamens);
+	formulaireImprimerDemandesAnalyses.appendChild(champ3);
+	
+	var champ4 = document.createElement("input");
+	champ4.setAttribute("type", "hidden");
+	champ4.setAttribute("name", 'tabIdExamens');
+	champ4.setAttribute("value", tabIdExamens);
+	formulaireImprimerDemandesAnalyses.appendChild(champ4);
+	
+	var champ5 = document.createElement("input");
+	champ5.setAttribute("type", "hidden");
+	champ5.setAttribute("name", 'tabMotifExamenDem');
+	champ5.setAttribute("value", tabMotifExamenDem);
+	formulaireImprimerDemandesAnalyses.appendChild(champ5);
+	
+	$("#imprimerExamensBioDemandesPopup").trigger('click'); 
+}
 
+//*** Impression d'un seule examen demandé 
+//*** Impression d'un seule examen demandé 
+//*** Impression d'un seule examen demandé 
 function imprimerUnExamenDemandePop(idLigneExamen){
 	
-	//alert(idLigneExamen);
 	var k = idLigneExamen;
-	var motifExamenDem = $('#motifExamenDem_'+k).val();
-	//alert($('#motifExamenDem_'+k).val());
 	
-	typeExamen = $('.type_analyse_name_'+k+' option:selected').val(); 
-	idExamen = $('.analyse_name_'+k+' option:selected').val();
-	libelleExamen = $('.analyse_name_'+k+' option:selected').text(); 
+	var idpatient = $("#idpatient").val();
+	var typeExamen = $('.type_analyse_name_'+k+' option:selected').val(); 
+	var motifExamenDem = "";
+	if(typeExamen == 6){
+		motifExamenDem = $('#motifExamenRadioDem_'+k).val();
+	}else{
+		motifExamenDem = $('#motifExamenDem_'+k).val();
+	}
+	var idExamen = $('.analyse_name_'+k+' option:selected').val();
+	var libelleExamen = $('.analyse_name_'+k+' option:selected').text(); 
 	
-	alert(typeExamen);
-	alert(idExamen);
-	alert(libelleExamen);
+	var lienUrl = tabUrl[0]+'public/consultation/impression-un-examen-demande';
+	var formulaireImprimerDemandeAnalyse = document.getElementById("formulaireUnExamenDemandePopup");
+	formulaireImprimerDemandeAnalyse.setAttribute("action", lienUrl);
+	formulaireImprimerDemandeAnalyse.setAttribute("method", "POST");
+	formulaireImprimerDemandeAnalyse.setAttribute("target", "_blank");
 	
+	// Ajout dynamique de champs dans le formulaire
+	var champ = document.createElement("input");
+	champ.setAttribute("type", "hidden");
+	champ.setAttribute("name", 'typeExamen');
+	champ.setAttribute("value", typeExamen);
+	formulaireImprimerDemandeAnalyse.appendChild(champ);
+	
+	var champ2 = document.createElement("input");
+	champ2.setAttribute("type", "hidden");
+	champ2.setAttribute("name", 'idExamen');
+	champ2.setAttribute("value", idExamen);
+	formulaireImprimerDemandeAnalyse.appendChild(champ2);
+	
+	var champ3 = document.createElement("input");
+	champ3.setAttribute("type", "hidden");
+	champ3.setAttribute("name", 'libelleExamen');
+	champ3.setAttribute("value", libelleExamen);
+	formulaireImprimerDemandeAnalyse.appendChild(champ3);
+	
+	var champ4 = document.createElement("input");
+	champ4.setAttribute("type", "hidden");
+	champ4.setAttribute("name", 'idpatient');
+	champ4.setAttribute("value", idpatient);
+	formulaireImprimerDemandeAnalyse.appendChild(champ4);
+	
+	var champ5 = document.createElement("input");
+	champ5.setAttribute("type", "hidden");
+	champ5.setAttribute("name", 'motifExamenDem');
+	champ5.setAttribute("value", motifExamenDem);
+	formulaireImprimerDemandeAnalyse.appendChild(champ5);
+	
+	$("#imprimerUnExamenDemandePopup").trigger('click'); 
 }
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1453,4 +1662,117 @@ function imprimerTraitementMedicamenteux(){
 	formulaireImprimerDemandesAnalyses.appendChild(champ6);
 	
 	$("#imprimerOrdonnance").trigger('click');
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+//Autres (Transfert / Hospitalisation / Rendez-Vous) --- Autres (Transfert / Hospitalisation / Rendez-Vous)
+//Autres (Transfert / Hospitalisation / Rendez-Vous) --- Autres (Transfert / Hospitalisation / Rendez-Vous)
+
+//***** Rendez-Vous --- Rendez-Vous --- Rendez-Vous *****/
+//***** Rendez-Vous --- Rendez-Vous --- Rendez-Vous *****/
+
+function initChampDateTimeEtMotifRendezVousForm()
+{
+	//GESTION DU CALENDRIER DU RENDEZ-VOUS MEDICAUX
+	//GESTION DU CALENDRIER DU RENDEZ-VOUS MEDICAUX
+	
+	$('#dateHeureRendezVous').datetimepicker(
+		$.datepicker.regional['fr'] = {
+			dateFormat: 'dd/mm/yy -', 
+			timeText: 'H:M', 
+			hourText: 'Heure', 
+			minuteText: 'Minute', 
+			currentText: 'Actuellement', 
+			closeText: 'F',
+			showAnim : 'bounce',
+			minDate : '0',
+		} 
+	);
+	
+	
+	//GESTION DES RENDEZ-VOUS MEDICAUX
+	//GESTION DES RENDEZ-VOUS MEDICAUX
+	
+	var valeurAutreMotif = "";
+
+	$('#rendezvousPreciserVSS input[name=rendezvousPreciserVSSoin]').click(function(){ 
+		var boutons = $('#rendezvousPreciserVSS input[name=rendezvousPreciserVSSoin]:checked');
+		var choixSelect = boutons.val();
+
+		if(choixSelect == 1){
+			$('#motifRendezVous').val(' Visite systÃ©matique').attr('readonly', true);
+			$('#rendervousLabelVS').css({'font-size':'17px', 'font-weight':'bold'});
+			$('#rendervousLabelS').css({'font-size':'14px', 'font-weight':'normal'});
+			$('#rendervousLabelA').css({'font-size':'14px', 'font-weight':'normal'});
+		}else 
+			if(choixSelect == 2){
+				$('#motifRendezVous').val(' Soin').attr('readonly', true);
+				$('#rendervousLabelS').css({'font-size':'17px', 'font-weight':'bold'});
+				$('#rendervousLabelVS').css({'font-size':'14px', 'font-weight':'normal'});
+				$('#rendervousLabelA').css({'font-size':'14px', 'font-weight':'normal'});
+			}else
+				if(choixSelect == 3){
+					$('#motifRendezVous').val(" "+valeurAutreMotif).attr('readonly', false).focus(); 
+					$('#rendervousLabelA').css({'font-size':'17px', 'font-weight':'bold'});
+					$('#rendervousLabelVS').css({'font-size':'14px', 'font-weight':'normal'});
+					$('#rendervousLabelS').css({'font-size':'14px', 'font-weight':'normal'});
+				}
+
+	});
+
+	$('#rendervousLabelVS').click(function(){ 
+		$('#rendervousLabelVSInput').trigger('click');
+		$('#rendervousLabelVSInput').trigger('click');
+	});
+
+	$('#rendervousLabelS').click(function(){ 
+		$('#rendervousLabelSInput').trigger('click');
+		$('#rendervousLabelSInput').trigger('click');
+	});
+
+	$('#rendervousLabelA').click(function(){ 
+		$('#rendervousLabelAInput').trigger('click');
+		$('#rendervousLabelAInput').trigger('click');
+	});
+
+
+	$('#motifRendezVous').keyup(function(){
+		valeurAutreMotif = $(this).val();
+	});
+	
+	//Init
+	$('#rendervousLabelVSInput').trigger('click');
+	$('#rendervousLabelVSInput').trigger('click');
 }

--- a/public/js/consultation/modifierConsultation.js
+++ b/public/js/consultation/modifierConsultation.js
@@ -204,7 +204,10 @@ function initialisationScript(agePatient) {
 		
 	});
 	
-	
+	$( "#terminerCons" ).click(function(){
+		affichageDesExamensDemandes();
+		envoyerLesDonneesASauvegarder();
+	});
 	
 	//APPLICATION DE LA POSOLOGIE AUTOMATIQUEMENT POUR LE CAS "DOULEUR"
 	//APPLICATION DE LA POSOLOGIE AUTOMATIQUEMENT POUR LE CAS "DOULEUR"
@@ -930,10 +933,11 @@ function annulerDemandesDesAnalysesAFaire() {
 		//Si la liste commence par le premier élément
 		//On supprime un par un jusqu'au dernier
 		if(jsupselDebut == 1){
-			setTimeout(function(){ 
+			setTimeout(function(){
 				//Enlever les icones indicateurs des analyses demandées
 				$(".signalDemandeEffectueIcon").remove();
-				supprimer_acte_selectionne(1); 
+				vider_analyse_selectionne(1);
+				supprimer_acte_selectionne(1);
 			},500);
 		}else{
 			setTimeout(function(){
@@ -953,6 +957,519 @@ function annulerDemandesDesAnalysesAFaire() {
 	jsel = 1;
 	iaj = 1;
 }
+
+
+//RESULTAT -- DEMANDE EXAMEN RADIOLOGIQUE -- DEMANDE EXAMEN RADIOLOGIQUE 
+//RESULTAT -- DEMANDE EXAMEN RADIOLOGIQUE -- DEMANDE EXAMEN RADIOLOGIQUE 
+var hauteurLabelContenu = 0;
+function ajoutChampResultatExamenRadio($id, $idexamenRadio, $libelleexamenRadio){
+	
+	var nbExamenRadio = $("#contenuResultatExamenRadio table tr").length;
+	
+	var champResultatExamen = ''+
+		           '<tr id="contenuResultExamen'+(nbExamenRadio+1)+'" class="designLabelResultatExamenComplementaire positionResultatExamenRadio'+$id+'" style="height:40px; width:100%;" >'+
+                 '<th style="width:100%; padding-right: 25px; vertical-align: top;" > '+
+                 '<div style="float:left; width: 100%;">'+
+                   '<label style="width: 100%; height:30px; text-align:left;" >'+
+                     '<span style="font-size: 12px;">&#11166; </span> <span id="textExamenRadio_'+$idexamenRadio+'" style="font-size: 13px; "> '+$libelleexamenRadio+' </span> '+
+                     '<input name="resultatExamenRadio_'+$idexamenRadio+'" id="resultatExamenRadio_'+$idexamenRadio+'" type="text" style="width: 75%; float: right;"> '+
+                   '</label>'+
+                 '</div>'+ 
+                 '</th>'+
+                 '</tr>';
+	
+	var existeResultatRadio = $('#contenuResultatExamenRadio table tr').hasClass('positionResultatExamenRadio'+$id);
+	
+	if(existeResultatRadio){
+		
+		var champResultatExamenReplace = ''+
+                 '<th style="width:100%; padding-right: 25px; vertical-align: top;" > '+
+                   '<div style="float:left; width: 100%;">'+
+                     '<label style="width: 100%; height:30px; text-align:left;" >'+
+                       '<span style="font-size: 12px;">&#11166; </span> <span id="textExamenRadio_'+$idexamenRadio+'" style="font-size: 13px; "> '+$libelleexamenRadio+' </span> '+
+                       '<input name="resultatExamenRadio_'+$idexamenRadio+'" id="resultatExamenRadio_'+$idexamenRadio+'" type="text" style="width: 75%; float: right;"> '+
+                       '</label>'+
+                   '</div>'+ 
+                 '</th>';
+		
+		$('.positionResultatExamenRadio'+$id).empty().html(champResultatExamenReplace);
+	}else{ 
+
+		hauteurLabelContenu = 45*parseInt(nbExamenRadio);
+		$(".titreResultatExamenRadioStyle").css({'height':hauteurLabelContenu+'px'});
+		$('#contenuResultatExamenRadio #contenuResultExamen'+nbExamenRadio).after(champResultatExamen);
+	}
+	
+}
+
+function supprimeChampResultatExamenRadio($id){
+	$('.positionResultatExamenRadio'+$id).remove();
+	hauteurLabelContenu -= 45;
+	$(".titreResultatExamenRadioStyle").css({'height':hauteurLabelContenu+'px'});
+	
+}
+
+function supprimeDroiteChampResultatExamenRadio($id, nbListeActe, elsup){
+	
+	//On supprime a partir de la ligne demandée et recréer toutes les lignes en bas
+	var tabPos = new Array();
+	var itp = 0;
+	for(var i = $id ; i <= nbListeActe ; i++ ){
+		
+		//On supprime les resultats unpar un 
+		$('.positionResultatExamenRadio'+i).remove();
+		
+		//On crée la nouvelle table avec les données à sauvegarder
+		if($('#type_analyse_name_'+i).val() == 6){
+			tabPos[itp++] = i;
+		}
+	}
+	
+	//Un champ résultat supprimé du fait de la suppression
+	//d'une ligne est supprimée dans la liste des demandes
+	if(elsup == 0){
+		var indiceDep = 0;
+		if($('#type_analyse_name_'+$id).val() == 6){
+			indiceDep = 1;
+		}
+		
+		setTimeout(function(){ 
+			//On recrée les différents champs
+			for(var i = indiceDep ; i < tabPos.length ; i++ ){
+				var $pos = tabPos[i]-1;
+				ajoutAutomatiqueChampsResultats($pos);
+			}
+		},1000);
+		
+	}
+	//Un champ résultat supprimé sans la suppression
+	//d'une ligne dans la liste des demandes
+	else{
+		setTimeout(function(){ 
+			//On recrée les différents champs
+			for(var i = 0 ; i < tabPos.length ; i++ ){
+				var $pos = tabPos[i];
+				ajoutAutomatiqueChampsResultats($pos);
+			}
+		},1000);
+	}
+
+	hauteurLabelContenu -= 45;
+	$(".titreResultatExamenRadioStyle").css({'height':hauteurLabelContenu+'px'});
+	
+}
+
+var tabDonneesMotifsDesExamensRadioSauvegardees = new Array();
+var tabDonneesMotifsDesExamensSauvegardees = new Array();
+
+function envoyerLesDonneesASauvegarder(){
+	
+	var scriptDonneesMotifsExamensAEnvoyer = "";
+	var indExamRadio = 0;
+	var indExamBio = 0;
+	
+	for(var i=0 ; i<indicesIdExamensRadio ; i++){
+		if(tabDonneesIdExamensRadioSauvegardees[i][0] == 0){
+			
+			var idExamenRadio = tabDonneesIdExamensRadioSauvegardees[i][2];
+			var motifExamenRadio = tabDonneesMotifsDesExamensRadioSauvegardees[idExamenRadio];
+			scriptDonneesMotifsExamensAEnvoyer +='<input type="hidden" name="idExamenRadio_'+(indExamRadio)+'" value="'+idExamenRadio+'" >';
+			scriptDonneesMotifsExamensAEnvoyer +='<input type="hidden" name="motifExamenRadio_'+(indExamRadio++)+'" value="'+motifExamenRadio+'" >';
+			
+		}
+	}
+	
+	for(var i=0 ; i<indicesIdExamens ; i++){
+			
+		var idExamenBio = tabDonneesIdExamensSauvegardees[i];
+		var motifExamenBio = tabDonneesMotifsDesExamensSauvegardees[idExamenBio];
+		scriptDonneesMotifsExamensAEnvoyer +='<input type="hidden" name="idExamenBio_'+(indExamBio)+'" value="'+idExamenBio+'" >';
+		scriptDonneesMotifsExamensAEnvoyer +='<input type="hidden" name="motifExamenBio_'+(indExamBio++)+'" value="'+motifExamenBio+'" >';
+			
+	}
+	
+	scriptDonneesMotifsExamensAEnvoyer +="<input type='hidden' name='nbExamenRadio' value='"+indExamRadio+"' >";
+	scriptDonneesMotifsExamensAEnvoyer +="<input type='hidden' name='nbExamenBio' value='"+indExamBio+"' >";
+	
+	$("#sauverLesInfosDesExamensRadioBioSaisisPopup").html(scriptDonneesMotifsExamensAEnvoyer);
+}
+
+var tabDonneesIdExamensRadioSauvegardees = new Array();
+var tabDonneesIdExamensSauvegardees = new Array();
+
+var indicesIdExamensRadio = 0;
+var indicesIdExamens = 0;
+
+function effectuerDesDemandesExamens(){
+	
+	$( "#imprimerDesDemandesExamensAvecSaisiMotifs" ).dialog({
+	    resizable: false,
+	    height:675,
+	    width:900,
+	    autoOpen: false,
+	    modal: true,
+	    buttons: {
+	    	
+	        "Terminer": function() {
+	        	
+	        	envoyerLesDonneesASauvegarder();
+	        	$( this ).dialog( "close" );
+	        	
+	        },
+	        
+	   }
+	});
+	
+	var tabIdExamens = affichageDesExamensDemandes();
+	if(tabIdExamens.length > 0){
+		$("#imprimerDesDemandesExamensAvecSaisiMotifs").dialog('open');
+	}else{
+		alert("Aucun examen n'est selectionne");
+	}
+}
+
+
+function affichageDesExamensDemandes(){
+	
+	indicesIdExamensRadio = 0;
+	indicesIdExamens = 0;
+	var tabTypesExamens = [];
+	var tabExamens = [];
+	var tabIdExamens = [];
+	var tabTarifsExamens =[];
+	for( var i = 1, j = 1; i <= nbListeActe(); i++ ){
+		if($('.type_analyse_name_'+i).val()) {
+			tabTypesExamens[j] = $('.type_analyse_name_'+i+' option:selected').text(); 
+			tabExamens[j] = $('.analyse_name_'+i+' option:selected').text(); 
+			tabIdExamens[j] = $('.analyse_name_'+i+' option:selected').val(); 
+			tabTarifsExamens[j] = $('#tarifActe'+i).val();
+			j++;
+		}
+	}
+	
+	$('#contenuimprimerDesDemandesExamensAvecSaisiMotifs table').toggle(false);
+	$('#contenuimprimerDesDemandesExamensAvecSaisiMotifs .contenuExamDemImprime').remove();
+	
+	
+	//*** RECUPERATION DES EXAMENS RADIOLOGIQUES --- RECUPERATION DES EXAMENS RADIOLOGIQUES 
+	//*** RECUPERATION DES EXAMENS RADIOLOGIQUES --- RECUPERATION DES EXAMENS RADIOLOGIQUES 
+	var examenRadioDemandeAajoute = "";
+	var scriptSauvegardeMotifExamenRadio = "";
+	for(var k=1 ; k<tabExamens.length ; k++){
+		var typeExamen = $('.type_analyse_name_'+k+' option:selected').val();
+		if( typeExamen == 6 ){
+			$('#contenuExamRadioDemImprime_0').toggle(true);
+			
+			var baliseMere = $('#codePourAjouterDesExamensDemandesAImprimer');
+			baliseMere.addClass('contenuExamDemImprime_'+k);
+			
+			//Creer les attributs name
+			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen input').attr('name', 'idExamenRadioDem_'+k);
+			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen textarea').attr({'name':'motifExamenRadioDem_'+k, 'id':'motifExamenRadioDem_'+k});
+			
+			var idExamen = tabIdExamens[k];
+			
+			//Ajouter les valeurs
+			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen input').val(idExamen);
+			$('.contenuExamDemImprime_'+k+' .libelleExamenDemandeAImprimer').html(tabExamens[k]);
+			
+			//Creer l'icone pdf pour imprimer un examens precis
+			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen #imageImpressionExamenPopPrecis').html('<img onclick="imprimerUnExamenDemandePop('+k+');" style="float: right; width: 20px; height: 20px; margin-top: 5px; cursor: pointer;" src="../images_icons/pdf.png"  title="Imprimer" >');
+			
+			//Sauvegarder les données saisies dans le champs
+			scriptSauvegardeMotifExamenRadio += "<script>"+
+			       "$('#motifExamenRadioDem_"+k+"').keyup(function(){"+
+				     "tabDonneesMotifsDesExamensRadioSauvegardees["+idExamen+"] = $('#motifExamenRadioDem_"+k+"').val();"+				
+			       "})"+
+			       ".change(function(){"+
+				     "tabDonneesMotifsDesExamensRadioSauvegardees["+idExamen+"] = $('#motifExamenRadioDem_"+k+"').val();"+				
+			       "});"+
+			       "$('#motifExamenRadioDem_"+k+"').val(tabDonneesMotifsDesExamensRadioSauvegardees["+idExamen+"]);"+
+			       "tabDonneesMotifsDesExamensRadioSauvegardees["+idExamen+"] = $('#motifExamenRadioDem_"+k+"').val();"+
+			       "</script>";
+
+			tabDonneesIdExamensRadioSauvegardees[indicesIdExamensRadio++] = idExamen;
+
+			//============================================
+			examenRadioDemandeAajoute += baliseMere.html();
+		}
+	}
+	//A PLACER APRES LA PREMIERE TABLE
+	$('#contenuExamRadioDemImprime_0').after(examenRadioDemandeAajoute+''+scriptSauvegardeMotifExamenRadio);
+
+	
+	//*** RECUPERATION DES EXAMENS BIOLOGIQUES --- RECUPERATION DES EXAMENS BIOLOGIQUES 
+	//*** RECUPERATION DES EXAMENS BIOLOGIQUES --- RECUPERATION DES EXAMENS BIOLOGIQUES 
+	var examenBioDemandeAajoute = "";
+	var scriptSauvegardeMotifExamenBio = "";
+	for(var k=1 ; k<tabExamens.length ; k++){
+		var typeExamen = $('.type_analyse_name_'+k+' option:selected').val();
+		if( typeExamen != 6 ){
+			$('#contenuExamBioDemImprime_0').toggle(true);
+			
+			var baliseMere = $('#codePourAjouterDesExamensDemandesAImprimer');
+			baliseMere.addClass('contenuExamDemImprime_'+k);
+			
+			//Creer les attributs name
+			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen input').attr('name', 'idExamenDem_'+k);
+			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen textarea').attr({'name':'motifExamenDem_'+k, 'id':'motifExamenDem_'+k});
+			
+			//Ajouter les valeurs
+			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen input').val(tabIdExamens[k]);
+			$('.contenuExamDemImprime_'+k+' .libelleExamenDemandeAImprimer').html(tabExamens[k]);
+			
+			//Creer l'icone pdf pour imprimer un examens precis
+			$('.contenuExamDemImprime_'+k+' .textareaBaliseSaisiMotifExamen #imageImpressionExamenPopPrecis').html('<img onclick="imprimerUnExamenDemandePop('+k+');" style="float: right; width: 20px; height: 20px; margin-top: 5px; cursor: pointer;" src="../images_icons/pdf.png"  title="Imprimer" >');
+			
+
+			//Sauvegarder les données saisies dans le champs
+			scriptSauvegardeMotifExamenBio += "<script>"+
+			       "$('#motifExamenDem_"+k+"').keyup(function(){"+
+				     "tabDonneesMotifsDesExamensSauvegardees["+tabIdExamens[k]+"] = $('#motifExamenDem_"+k+"').val();"+				
+			       "})"+
+			       ".change(function(){"+
+				     "tabDonneesMotifsDesExamensSauvegardees["+tabIdExamens[k]+"] = $('#motifExamenDem_"+k+"').val();"+				
+			       "});"+
+			       "$('#motifExamenDem_"+k+"').val(tabDonneesMotifsDesExamensSauvegardees["+tabIdExamens[k]+"]);"+
+			       "tabDonneesMotifsDesExamensSauvegardees["+tabIdExamens[k]+"] = $('#motifExamenDem_"+k+"').val();"+
+			       "</script>";
+			
+
+			tabDonneesIdExamensSauvegardees[indicesIdExamens++] = tabIdExamens[k];
+			
+			//============================================
+			examenBioDemandeAajoute += baliseMere.html();
+		}
+	}
+	
+	
+	//A PLACER APRES LA PREMIERE TABLE
+	$('#contenuExamBioDemImprime_0').after(examenBioDemandeAajoute+''+scriptSauvegardeMotifExamenBio);
+	
+	
+	return tabIdExamens;
+}
+
+
+function imprimerTousLesExamensRadioDemandesPop(){
+	
+	var idpatient = $("#idpatient").val();
+	
+	var tabTypesExamens = [];
+	var tabExamens = [];
+	var tabIdExamens = [];
+	var tabMotifExamenDem = [];
+	
+	for(var i = 1, j = 1; i <= nbListeActe(); i++ ){
+		var typeExamen = $('.type_analyse_name_'+i+' option:selected').val();
+		
+		if($('.type_analyse_name_'+i).val() &&  typeExamen == 6 ) {
+			tabTypesExamens[j] = $('.type_analyse_name_'+i+' option:selected').val(); 
+			tabExamens[j] = $('.analyse_name_'+i+' option:selected').text(); 
+			tabIdExamens[j] = $('.analyse_name_'+i+' option:selected').val(); 
+			tabMotifExamenDem[j] = $('#motifExamenRadioDem_'+i).val();
+			j++;
+		}
+	}
+	
+	
+	var lienUrl = tabUrl[0]+'public/consultation/impression-examens-radio-demandes';
+	var formulaireImprimerDemandesAnalyses = document.getElementById("formulaireExamensDemandesPopup");
+	formulaireImprimerDemandesAnalyses.setAttribute("action", lienUrl);
+	formulaireImprimerDemandesAnalyses.setAttribute("method", "POST");
+	formulaireImprimerDemandesAnalyses.setAttribute("target", "_blank");
+	
+	
+	// Ajout dynamique de champs dans le formulaire
+	var champ = document.createElement("input");
+	champ.setAttribute("type", "hidden");
+	champ.setAttribute("name", 'idpatient');
+	champ.setAttribute("value", idpatient);
+	formulaireImprimerDemandesAnalyses.appendChild(champ);
+	
+	var champ2 = document.createElement("input");
+	champ2.setAttribute("type", "hidden");
+	champ2.setAttribute("name", 'tabTypesExamens');
+	champ2.setAttribute("value", tabTypesExamens);
+	formulaireImprimerDemandesAnalyses.appendChild(champ2);
+	
+	var champ3 = document.createElement("input");
+	champ3.setAttribute("type", "hidden");
+	champ3.setAttribute("name", 'tabExamens');
+	champ3.setAttribute("value", tabExamens);
+	formulaireImprimerDemandesAnalyses.appendChild(champ3);
+	
+	var champ4 = document.createElement("input");
+	champ4.setAttribute("type", "hidden");
+	champ4.setAttribute("name", 'tabIdExamens');
+	champ4.setAttribute("value", tabIdExamens);
+	formulaireImprimerDemandesAnalyses.appendChild(champ4);
+	
+	var champ5 = document.createElement("input");
+	champ5.setAttribute("type", "hidden");
+	champ5.setAttribute("name", 'tabMotifExamenDem');
+	champ5.setAttribute("value", tabMotifExamenDem);
+	formulaireImprimerDemandesAnalyses.appendChild(champ5);
+	
+	$("#imprimerExamensDemandesPopup").trigger('click'); 
+}
+
+function imprimerTousLesExamensBioDemandesPop(){
+	
+	var idpatient = $("#idpatient").val();
+	
+	var tabTypesExamens = [];
+	var tabExamens = [];
+	var tabIdExamens = [];
+	var tabMotifExamenDem = [];
+	
+	for(var i = 1, j = 1; i <= nbListeActe(); i++ ){
+		var typeExamen = $('.type_analyse_name_'+i+' option:selected').val();
+		
+		if( $('.type_analyse_name_'+i).val() &&  typeExamen != 6 ) {
+			tabTypesExamens[j] = $('.type_analyse_name_'+i+' option:selected').val(); 
+			tabExamens[j] = $('.analyse_name_'+i+' option:selected').text(); 
+			tabIdExamens[j] = $('.analyse_name_'+i+' option:selected').val(); 
+			tabMotifExamenDem[j] = $('#motifExamenDem_'+i).val();
+			j++;
+		}
+	}
+	
+	var lienExamenBioUrl = tabUrl[0]+'public/consultation/impression-examens-bio-demandes';
+	var formulaireImprimerDemandesAnalyses = document.getElementById("formulaireExamensBioDemandesPopup");
+	formulaireImprimerDemandesAnalyses.setAttribute("action", lienExamenBioUrl);
+	formulaireImprimerDemandesAnalyses.setAttribute("method", "POST");
+	formulaireImprimerDemandesAnalyses.setAttribute("target", "_blank");
+	
+	// Ajout dynamique de champs dans le formulaire
+	var champ = document.createElement("input");
+	champ.setAttribute("type", "hidden");
+	champ.setAttribute("name", 'idpatient');
+	champ.setAttribute("value", idpatient);
+	formulaireImprimerDemandesAnalyses.appendChild(champ);
+	
+	var champ2 = document.createElement("input");
+	champ2.setAttribute("type", "hidden");
+	champ2.setAttribute("name", 'tabTypesExamens');
+	champ2.setAttribute("value", tabTypesExamens);
+	formulaireImprimerDemandesAnalyses.appendChild(champ2);
+	
+	var champ3 = document.createElement("input");
+	champ3.setAttribute("type", "hidden");
+	champ3.setAttribute("name", 'tabExamens');
+	champ3.setAttribute("value", tabExamens);
+	formulaireImprimerDemandesAnalyses.appendChild(champ3);
+	
+	var champ4 = document.createElement("input");
+	champ4.setAttribute("type", "hidden");
+	champ4.setAttribute("name", 'tabIdExamens');
+	champ4.setAttribute("value", tabIdExamens);
+	formulaireImprimerDemandesAnalyses.appendChild(champ4);
+	
+	var champ5 = document.createElement("input");
+	champ5.setAttribute("type", "hidden");
+	champ5.setAttribute("name", 'tabMotifExamenDem');
+	champ5.setAttribute("value", tabMotifExamenDem);
+	formulaireImprimerDemandesAnalyses.appendChild(champ5);
+	
+	$("#imprimerExamensBioDemandesPopup").trigger('click'); 
+}
+
+//*** Impression d'un seule examen demandé 
+//*** Impression d'un seule examen demandé 
+//*** Impression d'un seule examen demandé 
+function imprimerUnExamenDemandePop(idLigneExamen){
+	
+	var k = idLigneExamen;
+	
+	var idpatient = $("#idpatient").val();
+	var typeExamen = $('.type_analyse_name_'+k+' option:selected').val(); 
+	var motifExamenDem = "";
+	if(typeExamen == 6){
+		motifExamenDem = $('#motifExamenRadioDem_'+k).val();
+	}else{
+		motifExamenDem = $('#motifExamenDem_'+k).val();
+	}
+	var idExamen = $('.analyse_name_'+k+' option:selected').val();
+	var libelleExamen = $('.analyse_name_'+k+' option:selected').text(); 
+	
+	var lienUrl = tabUrl[0]+'public/consultation/impression-un-examen-demande';
+	var formulaireImprimerDemandeAnalyse = document.getElementById("formulaireUnExamenDemandePopup");
+	formulaireImprimerDemandeAnalyse.setAttribute("action", lienUrl);
+	formulaireImprimerDemandeAnalyse.setAttribute("method", "POST");
+	formulaireImprimerDemandeAnalyse.setAttribute("target", "_blank");
+	
+	// Ajout dynamique de champs dans le formulaire
+	var champ = document.createElement("input");
+	champ.setAttribute("type", "hidden");
+	champ.setAttribute("name", 'typeExamen');
+	champ.setAttribute("value", typeExamen);
+	formulaireImprimerDemandeAnalyse.appendChild(champ);
+	
+	var champ2 = document.createElement("input");
+	champ2.setAttribute("type", "hidden");
+	champ2.setAttribute("name", 'idExamen');
+	champ2.setAttribute("value", idExamen);
+	formulaireImprimerDemandeAnalyse.appendChild(champ2);
+	
+	var champ3 = document.createElement("input");
+	champ3.setAttribute("type", "hidden");
+	champ3.setAttribute("name", 'libelleExamen');
+	champ3.setAttribute("value", libelleExamen);
+	formulaireImprimerDemandeAnalyse.appendChild(champ3);
+	
+	var champ4 = document.createElement("input");
+	champ4.setAttribute("type", "hidden");
+	champ4.setAttribute("name", 'idpatient');
+	champ4.setAttribute("value", idpatient);
+	formulaireImprimerDemandeAnalyse.appendChild(champ4);
+	
+	var champ5 = document.createElement("input");
+	champ5.setAttribute("type", "hidden");
+	champ5.setAttribute("name", 'motifExamenDem');
+	champ5.setAttribute("value", motifExamenDem);
+	formulaireImprimerDemandeAnalyse.appendChild(champ5);
+	
+	$("#imprimerUnExamenDemandePopup").trigger('click'); 
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/public/js/facturation/jsAdmission.js
+++ b/public/js/facturation/jsAdmission.js
@@ -191,6 +191,9 @@ $('#precedent').click(function(){
 
 }
 
+
+var entreeValidation = 0;
+
 function admettre(idpatient){ 
 	
 	$("#termineradmission").replaceWith("<button id='termineradmission' style='height:35px;'>Terminer</button>");
@@ -224,6 +227,26 @@ function admettre(idpatient){
         	     $('#contenu').animate({
         	         height : 'toggle'
         	     },1000);
+        	     
+        	     
+        	     
+        	     
+        	     if(entreeValidation == 0){
+        	    	 entreeValidation = 1;
+                     $('.termineradmission button').click(function(){
+                    	 
+                    	 if($('#formulairePrincipal')[0].checkValidity() == true){
+                    		 //formulaire valide et envoi des données
+                    		 $('.termineradmission button').attr('disabled', true);
+                    		 $('#envoyerDonneesAdmission').trigger('click');
+            	    	 }else{
+            	    		 
+            	    		 $('#envoyerDonneesAdmission').trigger('click');
+            	    	 }
+            	    
+                     });
+        	     }
+
         	     
         },
         error:function(e){console.log(e);alert("Une erreur interne est survenue!");},

--- a/public/js/technicien/jsListeBilansTriesResultats.js
+++ b/public/js/technicien/jsListeBilansTriesResultats.js
@@ -587,6 +587,129 @@
     	
     }
     
+    function getAzotemieFormule(){ 
+    	var uree_sanguine = $('#uree_sanguine').val();
+    	var valeur_mmol = null;
+    	
+    	$('#uree_sanguine').keyup( function () { 
+    		uree_sanguine = $('#uree_sanguine').val(); 
+    		if(uree_sanguine){
+        		valeur_mmol = uree_sanguine * 16.65;
+        		$('#uree_sanguine_mmol').val(valeur_mmol.toFixed(2));
+        	}else{
+        		$('#uree_sanguine_mmol').val(null);
+        	}
+    	}).change( function(){
+    		uree_sanguine = $('#uree_sanguine').val(); 
+    		if(uree_sanguine){
+        		valeur_mmol = uree_sanguine * 16.65;
+        		$('#uree_sanguine_mmol').val(valeur_mmol.toFixed(2));
+        	}else{
+        		$('#uree_sanguine_mmol').val(null);
+        	}
+    	});
+    	
+    }
+    
+    function getAcideUriqueFormule(){ 
+    	var acide_urique = $('#acide_urique').val();
+    	var valeur_umol = null;
+    	
+    	$('#acide_urique').keyup( function () { 
+    		acide_urique = $('#acide_urique').val(); 
+    		if(acide_urique){
+        		valeur_umol = acide_urique * 5.949;
+        		$('#acide_urique_umol').val(valeur_umol.toFixed(0));
+        	}else{
+        		$('#acide_urique_umol').val(null);
+        	}
+    	}).change( function(){
+    		acide_urique = $('#acide_urique').val(); 
+    		if(acide_urique){
+        		valeur_umol = acide_urique * 5.949;
+        		$('#acide_urique_umol').val(valeur_umol.toFixed(0));
+        	}else{
+        		$('#acide_urique_umol').val(null);
+        	}
+    	});
+    	
+    }
+    
+    
+    function getCalcemieFormule(){ 
+    	var calcemie = $('#calcemie').val();
+    	var valeur_mmol = null;
+    	
+    	$('#calcemie').keyup( function () { 
+    		calcemie = $('#calcemie').val(); 
+    		if(calcemie){
+        		valeur_mmol = calcemie * 0.0249;
+        		$('#calcemie_mmol').val(valeur_mmol.toFixed(2));
+        	}else{
+        		$('#calcemie_mmol').val(null);
+        	}
+    	}).change( function(){
+    		calcemie = $('#calcemie').val(); 
+    		if(calcemie){
+        		valeur_mmol = calcemie * 0.0249;
+        		$('#calcemie_mmol').val(valeur_mmol.toFixed(2));
+        	}else{
+        		$('#calcemie_mmol').val(null);
+        	}
+    	});
+    	
+    }
+    
+    
+    function getPhosphoremieFormule(){ 
+    	var phosphoremie = $('#phosphoremie').val();
+    	var valeur_mmol = null;
+    	
+    	$('#phosphoremie').keyup( function () { 
+    		phosphoremie = $('#phosphoremie').val(); 
+    		if(phosphoremie){
+        		valeur_mmol = phosphoremie * 0.323;
+        		$('#phosphoremie_mmol').val(valeur_mmol.toFixed(2));
+        	}else{
+        		$('#phosphoremie_mmol').val(null);
+        	}
+    	}).change( function(){
+    		phosphoremie = $('#phosphoremie').val(); 
+    		if(phosphoremie){
+        		valeur_mmol = phosphoremie * 0.323;
+        		$('#phosphoremie_mmol').val(valeur_mmol.toFixed(2));
+        	}else{
+        		$('#phosphoremie_mmol').val(null);
+        	}
+    	});
+    	
+    }
+    
+    
+    function getAlbuminemieFormule(){ 
+    	var albuminemie = $('#albuminemie').val();
+    	var valeur_umol = null;
+    	
+    	$('#albuminemie').keyup( function () { 
+    		albuminemie = $('#albuminemie').val(); 
+    		if(albuminemie){
+        		valeur_umol = albuminemie * 14.493;
+        		$('#albuminemie_umol').val(valeur_umol.toFixed(2));
+        	}else{
+        		$('#albuminemie_umol').val(null);
+        	}
+    	}).change( function(){
+    		albuminemie = $('#albuminemie').val(); 
+    		if(albuminemie){
+        		valeur_umol = albuminemie * 14.493;
+        		$('#albuminemie_umol').val(valeur_umol.toFixed(2));
+        	}else{
+        		$('#albuminemie_umol').val(null);
+        	}
+    	});
+    	
+    }
+    
     
     // GESTION DE L'ANALYSE Culot_urinaire 
     // GESTION DE L'ANALYSE Culot_urinaire 
@@ -594,8 +717,8 @@
     
     var tabInfosCulotUrinaire = new Array();
     tabInfosCulotUrinaire[0] = "";
-    tabInfosCulotUrinaire[1] = "";
-    tabInfosCulotUrinaire[2] = "";
+    tabInfosCulotUrinaire[1] = '<input type="text" name="culot_urinaire_val_1" id="culot_urinaire_val_1" style="width:95%; text-align: left; padding-left: 3px;">';
+    tabInfosCulotUrinaire[2] = '<input type="text" name="culot_urinaire_val_2" id="culot_urinaire_val_2" style="width:95%; text-align: left; padding-left: 3px;">';
     tabInfosCulotUrinaire[3] = '<select name="culot_urinaire_val_3" id="culot_urinaire_val_3" style="width: 95%;"> ' +
     		                   "  <option></option> " +
     		                   "  <option value=1>Oxalate de potassium | calcium</option> " +
@@ -674,7 +797,7 @@
     		if(listeSelect2){ 
     			tab[2][j++] = listeSelect2;
     		}else{
-    			tab[2][j++] = null;
+    			tab[2][j++] = $('#culot_urinaire_ligne_'+i+' .emplaceListeElemtsCUSelect input').val();;
     		}
     	}
 	    tab[3] = $('#conclusion_culot_urinaire_valeur').val();
@@ -777,7 +900,8 @@
     	var tab = [];
     	tab[1] = $('#uree_sanguine').val(); 
 		tab[2] = $('#type_materiel_azotemie').val();
-    	
+		tab[3] = $('#uree_sanguine_mmol').val();
+		
     	return tab;
     }
     
@@ -811,7 +935,7 @@
        				else if(idanalyse ==  7) { tab    = vitesseSedimentation(); }
     				else if(idanalyse ==  8) { tab    = testDemmel(); }
     				else if(idanalyse ==  9) { tab[1] = $('#taux_reticulocyte').val(); tab[2] = $('#type_materiel_taux_reticulocytes').val(); } 
-    				else if(idanalyse == 10) { tab[1] = $('#goutte_epaisse').val(); tab[2] = $('#densite_parasitaire').val(); tab[3] = $('#type_materiel_goutte_epaisse').val(); }
+    				else if(idanalyse == 10) { tab[1] = $('#goutte_epaisse').val(); tab[2] = $('#densite_parasitaire').val(); tab[3] = $('#type_materiel_goutte_epaisse').val(); tab[4] = $('#commentaire_goutte_epaisse').val(); }
     				     
     				else if(idanalyse == 14) { tab    = getTpInr(); }
     				else if(idanalyse == 15) { tab    = getTca(); }
@@ -823,7 +947,7 @@
     				else if(idanalyse == 21) { tab[1] = $('#glycemie_1').val(); tab[2] = $('#glycemie_2').val(); tab[3] = $('#type_materiel_glycemie').val();}
     				else if(idanalyse == 22) { tab[1] = $('#creatininemie').val(); tab[2] = $('#type_materiel_creatininemie').val(); }
     				else if(idanalyse == 23) { tab    = azotemie(); }
-    				else if(idanalyse == 24) { tab[1] = $('#acide_urique').val(); tab[2] = $('#type_materiel_acide_urique').val(); }
+    				else if(idanalyse == 24) { tab[1] = $('#acide_urique').val(); tab[2] = $('#type_materiel_acide_urique').val(); tab[3] = $('#acide_urique_umol').val(); }
     				else if(idanalyse == 25) { tab[1] = $('#cholesterol_total_1').val(); tab[2] = $('#cholesterol_total_2').val(); tab[3] = $('#type_materiel_cholesterol_total').val(); } 
     				else if(idanalyse == 26) { tab[1] = $('#triglycerides_1').val(); tab[2] = $('#triglycerides_2').val(); tab[3] = $('#type_materiel_triglycerides').val(); }
     				else if(idanalyse == 27) { tab[1] = $('#cholesterol_HDL_1').val(); tab[2] = $('#cholesterol_HDL_2').val(); tab[3] = $('#type_materiel_cholesterol_HDL').val(); }
@@ -836,9 +960,9 @@
     				}
     				else if(idanalyse == 30) { tab = getLipidesTotaux(); }   
     				else if(idanalyse == 31) { tab = getIonogramme(); }     
-    				else if(idanalyse == 32) { tab[1] = $('#calcemie').val(); tab[2] = $('#type_materiel_calcemie').val(); }
+    				else if(idanalyse == 32) { tab[1] = $('#calcemie').val(); tab[2] = $('#type_materiel_calcemie').val(); tab[3] = $('#calcemie_mmol').val(); }
     				else if(idanalyse == 33) { tab[1] = $('#magnesemie').val(); tab[2] = $('#type_materiel_magnesemie').val(); }
-    				else if(idanalyse == 34) { tab[1] = $('#phosphoremie').val(); tab[2] = $('#type_materiel_phosphoremie').val(); }     
+    				else if(idanalyse == 34) { tab[1] = $('#phosphoremie').val(); tab[2] = $('#type_materiel_phosphoremie').val(); tab[3] = $('#phosphoremie_mmol').val(); }     
     				else if(idanalyse == 35) { tab = getAsat(); } 
     				else if(idanalyse == 36) { tab = getAlat(); }  
     				else if(idanalyse == 37) { tab = getAsatAlat(); }
@@ -925,6 +1049,11 @@
             	     getElectroHemo();
             	     getAsatAlatAuto();
             	     getFerSeriqueFormule();
+            	     getAzotemieFormule();
+            	     getAcideUriqueFormule();
+            	     getCalcemieFormule();
+            	     getPhosphoremieFormule();
+            	     getAlbuminemieFormule();
             	     
             	     ajoutCulotUrinaireAuto();
             	     getBilirubineTotaleDirecteAuto();
@@ -957,6 +1086,7 @@
     	tab[1] = $('#goutte_epaisse').val();
     	tab[2] = $('#densite_parasitaire').val();
     	tab[3] = $('#type_materiel_goutte_epaisse').val();
+    	tab[4] = $('#commentaire_goutte_epaisse').val();
     	
     	return tab;
     }
@@ -1276,6 +1406,7 @@
     	var tab = [];
     	tab[1] = $('#type_materiel_albuminemie').val();
     	tab[2] = $('#albuminemie').val();
+    	tab[3] = $('#albuminemie_umol').val();
 	    
 	    return tab;
     }
@@ -1323,6 +1454,7 @@
     	tab[1] = $('#type_materiel_hlm_compte_daddis').val();
     	tab[2] = $('#hematies_hlm').val();
     	tab[3] = $('#leucocytes_hlm').val();
+    	tab[4] = $('#commentaire_hlm_compte_daddis').val();
 	    
 	    return tab;
     }
@@ -1387,6 +1519,7 @@
     	tab[3] = $('#toxoplasmose_igm_titre').val();
     	tab[4] = $('#toxoplasmose_igg').val();
     	tab[5] = $('#toxoplasmose_igg_titre').val();
+    	tab[6] = $('#toxoplasmose_commentaire').val();
 	    
 	    return tab;
     }
@@ -1398,6 +1531,7 @@
     	tab[3] = $('#rubeole_igm_titre').val();
     	tab[4] = $('#rubeole_igg').val();
     	tab[5] = $('#rubeole_igg_titre').val();
+    	tab[6] = $('#rubeole_commentaire').val();
 	    
 	    return tab;
     }
@@ -1724,7 +1858,7 @@
     		triglycerides_1 = $('#triglycerides_1').val();
     		if(triglycerides_1){
         		valeur_mmol = triglycerides_1 * 1.143;
-        		$('#triglycerides_2').val(valeur_mmol.toFixed(3));
+        		$('#triglycerides_2').val(valeur_mmol.toFixed(2));
         	}else{
         		$('#triglycerides_2').val(null);
         	}
@@ -1994,7 +2128,7 @@
     				else if(idanalyse == 21) { tab [21] = getGlycemie(); }
     				else if(idanalyse == 22) { tab [22] = new Array("", $('#creatininemie').val(), $('#type_materiel_creatininemie').val()); }
     				else if(idanalyse == 23) { tab [23] = azotemie(); }
-    				else if(idanalyse == 24) { tab [24] = new Array("", $('#acide_urique').val(), $('#type_materiel_acide_urique').val()); }
+    				else if(idanalyse == 24) { tab [24] = new Array("", $('#acide_urique').val(), $('#type_materiel_acide_urique').val(), $('#acide_urique_umol').val()); }
     				else if(idanalyse == 25) { tab [25] = getCholesterolTotal(); }
     				else if(idanalyse == 26) { tab [26] = new Array("", $('#triglycerides_1').val(), $('#triglycerides_2').val(), $('#type_materiel_triglycerides').val()); }
     				else if(idanalyse == 27) { tab [27] = new Array("", $('#cholesterol_HDL_1').val(), $('#cholesterol_HDL_2').val(), $('#type_materiel_cholesterol_HDL').val()); }
@@ -2002,9 +2136,9 @@
     				else if(idanalyse == 29) { tab [29] = getChol_Total_HDL_LDL_Trigly(tabIdDemande[29]); }
     				else if(idanalyse == 30) { tab [30] = getLipidesTotaux(); } 
     			    else if(idanalyse == 31) { tab [31] = getIonogramme(); }
-    				else if(idanalyse == 32) { tab [32] = new Array("", $('#calcemie').val(), $('#type_materiel_calcemie').val()); } 
+    				else if(idanalyse == 32) { tab [32] = new Array("", $('#calcemie').val(), $('#type_materiel_calcemie').val(), $('#calcemie_mmol').val()); } 
     				else if(idanalyse == 33) { tab [33] = new Array("", $('#magnesemie').val(), $('#type_materiel_magnesemie').val()); }
-    				else if(idanalyse == 34) { tab [34] = new Array("", $('#phosphoremie').val(), $('#type_materiel_phosphoremie').val()); }
+    				else if(idanalyse == 34) { tab [34] = new Array("", $('#phosphoremie').val(), $('#type_materiel_phosphoremie').val(), $('#phosphoremie_mmol').val());  }
     				else if(idanalyse == 35) { tab [35] = getAsat(); }
     				else if(idanalyse == 36) { tab [36] = getAlat(); }
     				else if(idanalyse == 37) { tab [37] = getAsatAlat(); }
@@ -2100,6 +2234,11 @@
             	     getElectroHemo();
             	     getAsatAlatAuto();
             	     getFerSeriqueFormule();
+            	     getAzotemieFormule();
+            	     getAcideUriqueFormule();
+            	     getCalcemieFormule();
+            	     getPhosphoremieFormule();
+            	     getAlbuminemieFormule();
             	     
             	     ajoutCulotUrinaireAuto();
             	     getBilirubineTotaleDirecteAuto();
@@ -2351,6 +2490,7 @@
     	tab[1] = $('.ER_'+id+' #goutte_epaisse').val();
     	tab[2] = $('.ER_'+id+' #densite_parasitaire').val();
     	tab[3] = $('.ER_'+id+' #type_materiel_goutte_epaisse').val();
+    	tab[4] = $('.ER_'+id+' #commentaire_goutte_epaisse').val();
     	
     	return tab;
     }
@@ -2507,6 +2647,7 @@
     	
     	tab[1] = $('.ER_'+id+' #uree_sanguine').val(); 
 		tab[2] = $('.ER_'+id+' #type_materiel_azotemie').val();
+		tab[3] = $('.ER_'+id+' #uree_sanguine_mmol').val();
     	
     	return tab;
     }
@@ -2522,6 +2663,7 @@
     	
     	tab[1] = $('.ER_'+id+' #acide_urique').val(); 
     	tab[2] = $('.ER_'+id+' #type_materiel_acide_urique').val(); 
+    	tab[3] = $('.ER_'+id+' #acide_urique_umol').val(); 
     	
     	return tab;
     }
@@ -2651,6 +2793,7 @@
     	
     	tab[1] = $('.ER_'+id+' #calcemie').val();
     	tab[2] = $('.ER_'+id+' #type_materiel_calcemie').val();
+    	tab[3] = $('.ER_'+id+' #calcemie_mmol').val();
     	
     	return tab;
     }
@@ -2897,6 +3040,7 @@
     	
     	tab[1] = $('.ER_'+id+' #type_materiel_albuminemie').val();
     	tab[2] = $('.ER_'+id+' #albuminemie').val();
+    	tab[3] = $('.ER_'+id+' #albuminemie_umol').val();
 	    
 	    return tab;
     }
@@ -2972,6 +3116,7 @@
     	tab[1] = $('.ER_'+id+' #type_materiel_hlm_compte_daddis').val();
     	tab[2] = $('.ER_'+id+' #hematies_hlm').val();
     	tab[3] = $('.ER_'+id+' #leucocytes_hlm').val();
+    	tab[4] = $('.ER_'+id+' #commentaire_hlm_compte_daddis').val();
 	    
 	    return tab;
     }


### PR DESCRIPTION
L'imprimé sur les résultats des analyses est réécrite dans sa totalité (c.à.d : concernant toutes les 70 analyses). Cette fois ci, le plugin est fpdf (simple à utiliser et permet d'aller vite...) est utilisé pour la génération des imprimés à la place de zendPdf(très intéressant mais peu complexe et demande beaucoup de temps...).